### PR TITLE
feat: fix note patching

### DIFF
--- a/DragonglassApp/Dragonglass/AgentClient.swift
+++ b/DragonglassApp/Dragonglass/AgentClient.swift
@@ -1,6 +1,15 @@
 import Foundation
 import Combine
 
+struct ApprovalRequest: Identifiable {
+    let id: String
+    let tool: String
+    let permission: String
+    let path: String
+    let diff: String
+    let description: String
+}
+
 enum AgentEvent: Codable {
     case status(String)
     case assistantMessage(String)
@@ -13,6 +22,7 @@ enum AgentEvent: Codable {
     case conversationsList([ConversationMetadata])
     case conversationLoaded(String, [AgentEvent])
     case mcpTool(String, String, String, String)
+    case approvalRequest(ApprovalRequest)
     case unknown(String)
 
     enum CodingKeys: String, CodingKey {
@@ -31,6 +41,11 @@ enum AgentEvent: Codable {
         case history
         case phase
         case detail
+        case requestId = "request_id"
+        case permission
+        case path
+        case diff
+        case description
     }
 
     init(from decoder: Decoder) throws {
@@ -70,6 +85,15 @@ enum AgentEvent: Codable {
                 try container.decode(String.self, forKey: .message),
                 (try? container.decode(String.self, forKey: .detail)) ?? ""
             )
+        case "ApprovalRequestEvent":
+            self = .approvalRequest(ApprovalRequest(
+                id: try container.decode(String.self, forKey: .requestId),
+                tool: try container.decode(String.self, forKey: .tool),
+                permission: try container.decode(String.self, forKey: .permission),
+                path: try container.decode(String.self, forKey: .path),
+                diff: try container.decode(String.self, forKey: .diff),
+                description: try container.decode(String.self, forKey: .description)
+            ))
         default:
             self = .unknown(type)
         }
@@ -118,6 +142,8 @@ enum AgentEvent: Codable {
             try container.encode(phase, forKey: .phase)
             try container.encode(message, forKey: .message)
             try container.encode(detail, forKey: .detail)
+        case .approvalRequest:
+            break
         }
     }
 }
@@ -154,6 +180,7 @@ class AgentClient: ObservableObject {
     @Published var conversations: [ConversationMetadata] = []
     @Published var activeConversationId: String?
     @Published var llmBackend: String = "litellm"
+    @Published var pendingApproval: ApprovalRequest? = nil
     @Published var detailedToolEvents: Bool = UserDefaults.standard.bool(forKey: "detailedToolEvents") {
         didSet { UserDefaults.standard.set(detailedToolEvents, forKey: "detailedToolEvents") }
     }
@@ -258,8 +285,10 @@ class AgentClient: ObservableObject {
                                     self.availableModels = models
                                 case .userMessage:
                                     self.events.append(event)
+                                case .approvalRequest(let req):
+                                    self.events.append(event)
+                                    self.pendingApproval = req
                                 case .unknown, .usage, .configAck:
-                                    // These are system events or unknown, don't show in chat
                                     break
                                 }
                             } catch {
@@ -328,6 +357,22 @@ class AgentClient: ObservableObject {
 
     func stopChat() {
         send(["command": "stop"])
+        isThinking = false
+    }
+
+    func approveRequest(_ req: ApprovalRequest, forSession: Bool) {
+        var payload: [String: Any] = [
+            "command": forSession ? "approve_session" : "approve",
+            "request_id": req.id,
+        ]
+        if forSession { payload["permission"] = req.permission }
+        send(payload)
+        pendingApproval = nil
+    }
+
+    func rejectRequest(_ req: ApprovalRequest) {
+        send(["command": "reject", "request_id": req.id])
+        pendingApproval = nil
         isThinking = false
     }
 

--- a/DragonglassApp/Dragonglass/BackendManager.swift
+++ b/DragonglassApp/Dragonglass/BackendManager.swift
@@ -5,7 +5,8 @@ enum BackendPhase: Equatable {
     case installing
     case starting
     case ready
-    case needsPluginReload(String)
+    case needsPluginUpdate(String, String)  // (installedVersion, bundledVersion)
+    case needsPluginReload
     case obsidianUnreachable
     case obsidianVersionMismatch(String)
     case failed(String)
@@ -79,11 +80,9 @@ class BackendManager: ObservableObject {
         phase = .starting
         do {
             try await ensureOpencodeInstalled()
-            if let reloadMessage = await deployObsidianPlugin() {
-                phase = .needsPluginReload(reloadMessage)
-            }
+            let needsUserConfirm = await deployObsidianPlugin()
             try launchProcess()
-            if case .needsPluginReload = phase { } else {
+            if needsUserConfirm { } else {
                 // Wait for the backend to be actually responsive before setting .ready
                 print("[BackendManager] Waiting for health check...")
                 try await Task.sleep(nanoseconds: 6_000_000_000) // 6s initial delay for Python startup
@@ -213,12 +212,14 @@ class BackendManager: ObservableObject {
         return version
     }
 
-    /// Returns a non-nil reload message if the plugin was updated and Obsidian needs to reload it.
-    private func deployObsidianPlugin() async -> String? {
-        guard let pluginDir = obsidianPluginDir() else { return nil }
+    /// Checks if the bundled plugin differs from the installed one.
+    /// If versions differ, sets phase to needsPluginUpdate and returns true.
+    /// If not installed at all, copies silently and returns false.
+    private func deployObsidianPlugin() async -> Bool {
+        guard let pluginDir = obsidianPluginDir() else { return false }
         guard let bundledManifestUrl = Bundle.main.url(forResource: "manifest", withExtension: "json", subdirectory: "ObsidianPlugin"),
               let mainJsUrl = Bundle.main.url(forResource: "main", withExtension: "js", subdirectory: "ObsidianPlugin") else {
-            return nil
+            return false
         }
 
         let bundledVersion = readManifestVersion(at: bundledManifestUrl)
@@ -226,8 +227,14 @@ class BackendManager: ObservableObject {
         let installedVersion = readManifestVersion(at: installedManifestUrl)
         let alreadyInstalled = FileManager.default.fileExists(atPath: installedManifestUrl.path)
 
-        guard bundledVersion != installedVersion else { return nil }
+        guard bundledVersion != installedVersion else { return false }
 
+        if alreadyInstalled {
+            phase = .needsPluginUpdate(installedVersion ?? "?", bundledVersion ?? "?")
+            return true
+        }
+
+        // First install — copy silently
         do {
             try FileManager.default.createDirectory(at: pluginDir, withIntermediateDirectories: true)
             let destMain = pluginDir.appendingPathComponent("main.js")
@@ -236,16 +243,32 @@ class BackendManager: ObservableObject {
             if FileManager.default.fileExists(atPath: destManifest.path) { try FileManager.default.removeItem(at: destManifest) }
             try FileManager.default.copyItem(at: mainJsUrl, to: destMain)
             try FileManager.default.copyItem(at: bundledManifestUrl, to: destManifest)
-
             writeDragonglassConfig(to: pluginDir)
-
-            if alreadyInstalled {
-                return "The Vector Search plugin was updated (\(installedVersion ?? "?") → \(bundledVersion ?? "?")). Please toggle it off and on in Obsidian → Settings → Community plugins."
-            }
         } catch {
             print("[BackendManager] Plugin deploy failed: \(error)")
         }
-        return nil
+        return false
+    }
+
+    func applyPluginUpdate() {
+        guard let pluginDir = obsidianPluginDir(),
+              let bundledManifestUrl = Bundle.main.url(forResource: "manifest", withExtension: "json", subdirectory: "ObsidianPlugin"),
+              let mainJsUrl = Bundle.main.url(forResource: "main", withExtension: "js", subdirectory: "ObsidianPlugin") else {
+            return
+        }
+        do {
+            try FileManager.default.createDirectory(at: pluginDir, withIntermediateDirectories: true)
+            let destMain = pluginDir.appendingPathComponent("main.js")
+            let destManifest = pluginDir.appendingPathComponent("manifest.json")
+            if FileManager.default.fileExists(atPath: destMain.path) { try FileManager.default.removeItem(at: destMain) }
+            if FileManager.default.fileExists(atPath: destManifest.path) { try FileManager.default.removeItem(at: destManifest) }
+            try FileManager.default.copyItem(at: mainJsUrl, to: destMain)
+            try FileManager.default.copyItem(at: bundledManifestUrl, to: destManifest)
+            writeDragonglassConfig(to: pluginDir)
+            phase = .needsPluginReload
+        } catch {
+            print("[BackendManager] Plugin update failed: \(error)")
+        }
     }
 
     private func writeDragonglassConfig(to pluginDir: URL) {

--- a/DragonglassApp/Dragonglass/ContentView.swift
+++ b/DragonglassApp/Dragonglass/ContentView.swift
@@ -87,6 +87,7 @@ struct ContentView: View {
         .onChange(of: backend.phase) { _, phase in
             if phase == .ready || ({
                 if case .needsPluginReload = phase { return true }
+                if case .needsPluginUpdate = phase { return true }
                 return false
             }()) {
                 if !client.isConnected { client.connect() }
@@ -175,11 +176,22 @@ struct ContentView: View {
                 ProgressView("Installing dependencies...")
             case .starting:
                 ProgressView("Starting backend...")
-            case .needsPluginReload(let message):
+            case .needsPluginUpdate(let from, let to):
                 Image(systemName: "arrow.triangle.2.circlepath")
                     .font(.largeTitle)
                     .foregroundColor(.orange)
-                Text(message)
+                Text("A plugin update is available (\(from) → \(to)). Update now?")
+                    .multilineTextAlignment(.center)
+                    .padding()
+                Button("Update Plugin") {
+                    backend.applyPluginUpdate()
+                }
+                .buttonStyle(.borderedProminent)
+            case .needsPluginReload:
+                Image(systemName: "checkmark.circle")
+                    .font(.largeTitle)
+                    .foregroundColor(.green)
+                Text("Plugin updated. Toggle it off and on in Obsidian → Settings → Community plugins to apply.")
                     .multilineTextAlignment(.center)
                     .padding()
                 Button("Done") {

--- a/DragonglassApp/Dragonglass/ContentView.swift
+++ b/DragonglassApp/Dragonglass/ContentView.swift
@@ -25,6 +25,10 @@ struct ContentView: View {
             inputArea
         }
         .frame(width: 400, height: 500)
+        .sheet(item: $client.pendingApproval) { req in
+            ApprovalView(request: req)
+                .environmentObject(client)
+        }
     }
 
     private var header: some View {
@@ -303,7 +307,7 @@ struct ContentView: View {
                 .onSubmit(sendMessage)
                 .disabled(client.isThinking)
 
-            if client.isThinking {
+            if client.isThinking && client.pendingApproval == nil {
                 Button(action: { client.stopChat() }) {
                     Image(systemName: "stop.fill")
                         .font(.body)
@@ -313,7 +317,7 @@ struct ContentView: View {
                         .cornerRadius(4)
                 }
                 .buttonStyle(.plain)
-            } else {
+            } else if !client.isThinking {
                 Button(action: sendMessage) {
                     Image(systemName: "paperplane.fill")
                 }
@@ -405,6 +409,17 @@ struct EventRow: View {
                     .background(Color.accentColor.opacity(0.1))
                     .cornerRadius(8)
             }
+        case .approvalRequest(let req):
+            HStack(spacing: 6) {
+                Image(systemName: "pencil.circle")
+                    .foregroundColor(.orange)
+                Text("Pending approval: \(req.description)")
+                    .font(.caption)
+                    .foregroundColor(.orange)
+            }
+            .padding(4)
+            .background(Color.orange.opacity(0.08))
+            .cornerRadius(4)
         case .unknown(let type):
             Text("Unknown event: \(type)")
                 .font(.caption)
@@ -487,6 +502,85 @@ private struct BottomVisibilityKey: PreferenceKey {
     static let defaultValue: CGFloat = 0
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
         value = nextValue()
+    }
+}
+
+struct DiffView: View {
+    let diff: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(Array(diff.components(separatedBy: "\n").enumerated()), id: \.offset) { _, line in
+                Text(line.isEmpty ? " " : line)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundColor(lineColor(line))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(lineBackground(line))
+            }
+        }
+    }
+
+    private func lineColor(_ line: String) -> Color {
+        if line.hasPrefix("+") { return .green }
+        if line.hasPrefix("-") { return .red }
+        if line.hasPrefix("@") { return .blue }
+        return .primary
+    }
+
+    private func lineBackground(_ line: String) -> Color {
+        if line.hasPrefix("+") { return Color.green.opacity(0.08) }
+        if line.hasPrefix("-") { return Color.red.opacity(0.08) }
+        return .clear
+    }
+}
+
+struct ApprovalView: View {
+    @EnvironmentObject var client: AgentClient
+    let request: ApprovalRequest
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Approve Edit?")
+                .font(.headline)
+
+            Text(request.description)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+
+            if !request.diff.isEmpty {
+                ScrollView {
+                    DiffView(diff: request.diff)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .frame(maxHeight: 200)
+                .background(Color(NSColor.textBackgroundColor))
+                .cornerRadius(6)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
+                )
+            }
+
+            HStack {
+                Button("Reject") {
+                    client.rejectRequest(request)
+                }
+                .foregroundColor(.red)
+
+                Spacer()
+
+                Button("Approve for Session") {
+                    client.approveRequest(request, forSession: true)
+                }
+
+                Button("Approve") {
+                    client.approveRequest(request, forSession: false)
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding()
+        .frame(width: 420, height: 340)
     }
 }
 

--- a/DragonglassApp/scripts/bundle_resources.sh
+++ b/DragonglassApp/scripts/bundle_resources.sh
@@ -146,5 +146,5 @@ fi
   $PNPM_RUNNER build
 )
 
-cp "$PLUGIN_DIR/main.js" "$PLUGIN_RES_DIR/main.js"
-cp "$PLUGIN_DIR/manifest.json" "$PLUGIN_RES_DIR/manifest.json"
+cp "$PLUGIN_DIR/dist/main.js" "$PLUGIN_RES_DIR/main.js"
+cp "$PLUGIN_DIR/dist/manifest.json" "$PLUGIN_RES_DIR/manifest.json"

--- a/dragonglass/agent/agent.py
+++ b/dragonglass/agent/agent.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import asyncio
 import collections.abc
 import contextlib
+import difflib
 import json
 import logging
 import os
@@ -10,6 +12,7 @@ import subprocess
 import typing
 import uuid
 
+import httpx
 import litellm
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
@@ -20,6 +23,7 @@ from dragonglass.agent.opencode import run_opencode_turn
 from dragonglass.agent.prompts import load_system_prompt
 from dragonglass.agent.types import (
     AgentEvent,
+    ApprovalRequestEvent,
     DoneEvent,
     JsonValue,
     MCPToolEvent,
@@ -36,7 +40,14 @@ from dragonglass.agent.types import (
     _ToolFunction,
 )
 from dragonglass.config import Settings, get_settings
-from dragonglass.mcp.search import create_search_server
+from dragonglass.mcp.search import (
+    _delete_frontmatter_key_lines,
+    _rebuild_note_with_frontmatter,
+    _remove_inline_tags,
+    _set_frontmatter_key_lines,
+    _split_frontmatter_block,
+    create_search_server,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +98,14 @@ def _is_error_result(result: str) -> bool:
     except json.JSONDecodeError:
         return False
 
+
+_TOOL_PERMISSIONS: dict[str, str] = {
+    "dragonglass_replace_lines": "edit",
+    "dragonglass_insert_after_line": "edit",
+    "dragonglass_delete_lines": "delete",
+    "dragonglass_manage_frontmatter": "edit",
+    "dragonglass_manage_tags": "edit",
+}
 
 _TOOL_STATUS: dict[str, str] = {
     "fetch": "fetching",
@@ -320,6 +339,9 @@ class VaultAgent:
         self.agents_note_found: bool = False
         self._total_tokens: int = 0
         self._opencode_session_id: str | None = None
+        self._approval_gates: dict[str, asyncio.Event] = {}
+        self._approval_results: dict[str, bool] = {}
+        self._session_approved: set[str] = set()
 
     async def initialise(self) -> None:
         self._system_prompt, self.agents_note_found = await load_system_prompt(
@@ -331,6 +353,7 @@ class VaultAgent:
         self._history = []
         self._total_tokens = 0
         self._opencode_session_id = None
+        self._session_approved.clear()
 
     def get_history(self) -> list[_Message]:
         return list(self._history)
@@ -409,6 +432,158 @@ class VaultAgent:
 
         new_messages = messages[2 + history_len_before :]
         self._history.extend(new_messages)
+
+    def _needs_approval(  # noqa: PLR0911
+        self,
+        tool_name: str,
+        args: dict[str, JsonValue],
+        settings: Settings,
+    ) -> str | None:
+        perm = _TOOL_PERMISSIONS.get(tool_name)
+        if perm is None:
+            return None
+        if (
+            tool_name == "dragonglass_manage_frontmatter"
+            and args.get("operation") == "get"
+        ):
+            return None
+        if tool_name == "dragonglass_manage_tags" and args.get("operation") == "list":
+            return None
+        if perm == "edit" and settings.auto_allow_edit:
+            return None
+        if perm == "delete" and settings.auto_allow_delete:
+            return None
+        if perm == "create" and settings.auto_allow_create:
+            return None
+        if perm in self._session_approved:
+            return None
+        return perm
+
+    @staticmethod
+    async def _compute_diff(  # noqa: PLR0912, PLR0914, PLR0915
+        tool_name: str,
+        args: dict[str, JsonValue],
+    ) -> tuple[str, str, str]:
+        settings = get_settings()
+        path = str(args.get("path", ""))
+        if not path:
+            return "", "", tool_name
+
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.get(
+                    f"{settings.vector_search_url}/notes/read",
+                    params={"path": path},
+                )
+            if resp.status_code != 200:  # noqa: PLR2004
+                return path, "", f"{tool_name} on {path}"
+            data = resp.json()
+            original = str(data.get("content", ""))
+        except Exception:
+            logger.warning("approval gate: failed to fetch %r for diff", path)
+            return path, "", f"{tool_name} on {path}"
+
+        original_lines = original.splitlines(keepends=True)
+
+        try:
+            if tool_name == "dragonglass_replace_lines":
+                start = int(typing.cast(int, args.get("start_line", 1)))
+                end = int(typing.cast(int, args.get("end_line", start)))
+                replacement = str(args.get("replacement", ""))
+                new_lines = list(original_lines)
+                new_lines[start - 1 : end] = [
+                    ln if ln.endswith("\n") else ln + "\n"
+                    for ln in replacement.splitlines()
+                ]
+                description = f"Replace lines {start}-{end} in {path}"
+
+            elif tool_name == "dragonglass_insert_after_line":
+                line = int(typing.cast(int, args.get("line", 0)))
+                text = str(args.get("text", ""))
+                new_lines = list(original_lines)
+                insert_lines = [
+                    ln if ln.endswith("\n") else ln + "\n" for ln in text.splitlines()
+                ]
+                new_lines[line:line] = insert_lines
+                description = f"Insert after line {line} in {path}"
+
+            elif tool_name == "dragonglass_delete_lines":
+                start = int(typing.cast(int, args.get("start_line", 1)))
+                end = int(typing.cast(int, args.get("end_line", start)))
+                new_lines = list(original_lines)
+                del new_lines[start - 1 : end]
+                description = f"Delete lines {start}-{end} in {path}"
+
+            elif tool_name == "dragonglass_manage_frontmatter":
+                op = str(args.get("operation", ""))
+                key = str(args.get("key", ""))
+                value = args.get("value")
+                fm_lines, rest, had = _split_frontmatter_block(original)
+                if op == "set":
+                    fm_lines = _set_frontmatter_key_lines(fm_lines, key, value)
+                elif op == "delete":
+                    fm_lines, _ = _delete_frontmatter_key_lines(fm_lines, key)
+                new_content = _rebuild_note_with_frontmatter(fm_lines, rest, had)
+                new_lines = new_content.splitlines(keepends=True)
+                description = f"Frontmatter {op} '{key}' in {path}"
+
+            elif tool_name == "dragonglass_manage_tags":
+                op = str(args.get("operation", ""))
+                tags = args.get("tags", [])
+                tags_list = tags if isinstance(tags, list) else []
+                fm_lines, rest, had = _split_frontmatter_block(original)
+                if op == "remove":
+                    body = rest.lstrip("\n")
+                    updated_body = _remove_inline_tags(
+                        body, {str(t) for t in tags_list}
+                    )
+                    new_content = _rebuild_note_with_frontmatter(
+                        fm_lines,
+                        f"\n{updated_body}" if rest.startswith("\n") else updated_body,
+                        had,
+                    )
+                    new_lines = new_content.splitlines(keepends=True)
+                else:
+                    new_lines = original_lines
+                description = f"Tags {op} {tags_list!r} in {path}"
+
+            else:
+                return path, "", f"{tool_name} on {path}"
+
+        except Exception:
+            logger.warning(
+                "approval gate: diff computation failed for %r",
+                tool_name,
+                exc_info=True,
+            )
+            return path, "", f"{tool_name} on {path}"
+
+        diff_lines = list(
+            difflib.unified_diff(
+                original_lines,
+                new_lines,
+                fromfile=f"a/{path}",
+                tofile=f"b/{path}",
+                n=3,
+            )
+        )
+        return path, "".join(diff_lines), description
+
+    def resolve_approval(
+        self,
+        request_id: str,
+        approved: bool,
+        session: bool = False,
+        permission: str | None = None,
+    ) -> None:
+        self._approval_results[request_id] = approved
+        if session and permission and approved:
+            self._session_approved.add(permission)
+        gate = self._approval_gates.get(request_id)
+        if gate:
+            gate.set()
+        else:
+            logger.warning("resolve_approval: no pending gate for %r", request_id)
 
     async def _agent_loop(  # noqa: PLR0912, PLR0914, PLR0915
         self,
@@ -669,6 +844,36 @@ class VaultAgent:
                 if status:
                     yield StatusEvent(message=status)
 
+                perm = self._needs_approval(tool_name, args, settings)
+                if perm is not None:
+                    request_id = uuid.uuid4().hex
+                    path, diff_text, description = await VaultAgent._compute_diff(
+                        tool_name, args
+                    )
+                    gate = asyncio.Event()
+                    self._approval_gates[request_id] = gate
+                    yield ApprovalRequestEvent(
+                        request_id=request_id,
+                        tool=tool_name,
+                        permission=perm,
+                        path=path,
+                        diff=diff_text,
+                        description=description,
+                    )
+                    try:
+                        await asyncio.wait_for(gate.wait(), timeout=120.0)
+                    except TimeoutError:
+                        self._approval_gates.pop(request_id, None)
+                        yield StatusEvent(message="Approval timed out — edit cancelled")
+                        yield DoneEvent()
+                        return
+                    finally:
+                        self._approval_gates.pop(request_id, None)
+                    if not self._approval_results.pop(request_id, False):
+                        yield StatusEvent(message="Edit rejected")
+                        yield DoneEvent()
+                        return
+
                 call_key = (tool_name, json.dumps(args, sort_keys=True))
                 if call_key in seen_calls:
                     result = seen_calls[call_key]
@@ -698,7 +903,9 @@ class VaultAgent:
             "dragonglass_vector_search",
             "dragonglass_run_command",
             "dragonglass_read_note_with_hash",
-            "dragonglass_patch_note_lines",
+            "dragonglass_replace_lines",
+            "dragonglass_insert_after_line",
+            "dragonglass_delete_lines",
             "dragonglass_manage_frontmatter",
             "dragonglass_manage_tags",
         }

--- a/dragonglass/agent/system_prompt.md
+++ b/dragonglass/agent/system_prompt.md
@@ -44,17 +44,20 @@ Link related notes using `[[wikilinks]]` for any notes encountered during search
 
 Always inform the user when the edit has finished with what has been added.
 
-### In-file Edits (Patching)
-For edits inside an existing file, prefer the hash-gated flow below over text search/replace.
-1. Call `dragonglass_read_note_with_hash(path)`.
-2. Compute exact line numbers to change from the returned content (prefixed with `LX:`).
-3. Call `dragonglass_patch_note_lines(path, start_line, end_line, replacement)`.
-4. **Verify your edit**: Immediately call `dragonglass_read_note_with_hash(path, start_line, end_line)` on the affected range. This confirms the write and captures the new hash.
+### In-file Edits
+For edits inside an existing file, follow this flow:
+1. Call `dragonglass_read_note_with_hash(path)` — content is returned with line numbers prefixed as `LX:`.
+2. Identify the exact line numbers you need to change from the returned content.
+3. Call the appropriate tool:
+   - **`dragonglass_replace_lines(path, start_line, end_line, replacement)`** — rewrites existing lines. Use when modifying existing content (e.g. updating a sentence). Do NOT use this to insert new content.
+   - **`dragonglass_insert_after_line(path, line, text)`** — inserts new lines after the given line without touching existing content. Use for adding new sentences, items, or paragraphs. To append to the end of the file, use the last line number.
+   - **`dragonglass_delete_lines(path, start_line, end_line)`** — removes lines entirely.
+4. **Verify your edit**: Immediately call `dragonglass_read_note_with_hash(path, start_line, end_line)` on the affected range to confirm the write and capture the new hash.
 5. If `hash_mismatch`, re-read the note, recompute line numbers, and retry once.
 
-### Appending or Creating Notes
-- **`dragonglass_patch_note_lines`**: Use line-based patching for edits. For appends, read the file to get its last line and patch at the end.
-- **New Notes**: Create a new note only if necessary. Choose a descriptive title and appropriate folder. Keep the note focused on one topic.
+### Creating Notes
+- **New Notes**: Create a new note only if necessary. Keep the note focused on one topic.
+- **Inbox**: Place new notes in the inbox directory specified in the vault instructions. If no inbox is defined and you cannot confidently infer the correct folder from context, tell the user you don't know where to put the note and ask them to specify a folder or define an inbox in their vault instructions.
 
 ### Write Mode Ambiguity
 
@@ -70,7 +73,11 @@ For edits inside an existing file, prefer the hash-gated flow below over text se
 
 **`dragonglass_read_note_with_hash`** — returns content with line numbers (e.g., `L10: content`) and captures the hash of the ENTIRE file. Use optional `start_line` and `end_line` for targeted reading or verification.
 
-**`dragonglass_patch_note_lines`** — replace a 1-based inclusive line range. Enforces hash checks for atomicity.
+**`dragonglass_replace_lines`** — replace a 1-based inclusive line range. Use only for modifying existing content, not for insertion.
+
+**`dragonglass_insert_after_line`** — insert text after a given line without overwriting anything.
+
+**`dragonglass_delete_lines`** — delete a 1-based inclusive line range.
 
 **`dragonglass_manage_frontmatter`** — get, set, or delete YAML frontmatter keys.
 

--- a/dragonglass/agent/types.py
+++ b/dragonglass/agent/types.py
@@ -84,6 +84,16 @@ class MCPToolEvent:
 
 
 @dataclasses.dataclass
+class ApprovalRequestEvent:
+    request_id: str
+    tool: str
+    permission: str
+    path: str
+    diff: str
+    description: str
+
+
+@dataclasses.dataclass
 class ConversationsListEvent:
     conversations: list[dict[str, typing.Any]]
 
@@ -103,4 +113,5 @@ AgentEvent = (
     | ConversationsListEvent
     | ConversationLoadedEvent
     | UserMessageEvent
+    | ApprovalRequestEvent
 )

--- a/dragonglass/mcp/search.py
+++ b/dragonglass/mcp/search.py
@@ -731,7 +731,7 @@ async def do_patch_note_lines(  # noqa: PLR0911
         return {
             "error": (
                 "No stored hash for this file. Call dragonglass_read_note_with_hash(path) before "
-                "dragonglass_patch_note_lines(path, ...)."
+                "calling any note edit tool."
             )
         }
 
@@ -938,21 +938,22 @@ def create_search_server(settings: Settings) -> fastmcp.FastMCP:  # noqa: PLR091
         )
         return result
 
-    @m.tool(name="dragonglass_patch_note_lines")
-    async def patch_note_lines(
+    @m.tool(name="dragonglass_replace_lines")
+    async def replace_lines(
         path: str,
         start_line: int,
         end_line: int,
         replacement: str,
         expected_hash: str | None = None,
     ) -> dict[str, typing.Any]:
-        """Replace a 1-based inclusive line range in a markdown note.
+        """Replace a 1-based inclusive line range in a note with new text.
 
-        If expected_hash is omitted, the tool uses the hash captured by
-        read_note_with_hash(path) from the current search session.
-        Note that read_note_with_hash captures the hash of the ENTIRE file,
-        which is required for this tool to ensure atomicity even if only
-        a subset of lines was read.
+        Use this when you need to modify existing content (e.g. rewrite a sentence
+        or paragraph). Do NOT use this to insert — use dragonglass_insert_after_line
+        instead, as using replace for insertion will overwrite existing lines.
+
+        If expected_hash is omitted, uses the hash from the current session
+        (captured by read_note_with_hash). The hash covers the entire file.
         """
         started = time.monotonic()
         result = await do_patch_note_lines(
@@ -973,9 +974,91 @@ def create_search_server(settings: Settings) -> fastmcp.FastMCP:  # noqa: PLR091
             else f"ok ({elapsed:.2f}s)"
         )
         emit_tool_event(
-            "dragonglass_patch_note_lines",
+            "dragonglass_replace_lines",
             phase,
-            f"Patching: {_safe_value_preview(path, 60)} lines {start_line}-{end_line}",
+            f"Replacing: {_safe_value_preview(path, 60)} lines {start_line}-{end_line}",
+            detail,
+        )
+        return result
+
+    @m.tool(name="dragonglass_insert_after_line")
+    async def insert_after_line(
+        path: str,
+        line: int,
+        text: str,
+        expected_hash: str | None = None,
+    ) -> dict[str, typing.Any]:
+        """Insert new text after a given 1-based line number without overwriting anything.
+
+        Use this to add new content (new sentences, list items, paragraphs) after
+        an existing line. To append to the end of the file, pass the last line number.
+
+        If expected_hash is omitted, uses the hash from the current session
+        (captured by read_note_with_hash).
+        """
+        started = time.monotonic()
+        result = await do_patch_note_lines(
+            settings,
+            {
+                "path": path,
+                "start_line": line + 1,
+                "end_line": line,
+                "replacement": text,
+                "expected_hash": expected_hash,
+            },
+        )
+        elapsed = time.monotonic() - started
+        phase = "error" if "error" in result else "done"
+        detail = (
+            _safe_value_preview(result.get("error"))
+            if "error" in result
+            else f"ok ({elapsed:.2f}s)"
+        )
+        emit_tool_event(
+            "dragonglass_insert_after_line",
+            phase,
+            f"Inserting: {_safe_value_preview(path, 60)} after line {line}",
+            detail,
+        )
+        return result
+
+    @m.tool(name="dragonglass_delete_lines")
+    async def delete_lines(
+        path: str,
+        start_line: int,
+        end_line: int,
+        expected_hash: str | None = None,
+    ) -> dict[str, typing.Any]:
+        """Delete a 1-based inclusive line range from a note.
+
+        Use this to remove lines entirely. To replace content, use
+        dragonglass_replace_lines instead.
+
+        If expected_hash is omitted, uses the hash from the current session
+        (captured by read_note_with_hash).
+        """
+        started = time.monotonic()
+        result = await do_patch_note_lines(
+            settings,
+            {
+                "path": path,
+                "start_line": start_line,
+                "end_line": end_line,
+                "replacement": "",
+                "expected_hash": expected_hash,
+            },
+        )
+        elapsed = time.monotonic() - started
+        phase = "error" if "error" in result else "done"
+        detail = (
+            _safe_value_preview(result.get("error"))
+            if "error" in result
+            else f"ok ({elapsed:.2f}s)"
+        )
+        emit_tool_event(
+            "dragonglass_delete_lines",
+            phase,
+            f"Deleting: {_safe_value_preview(path, 60)} lines {start_line}-{end_line}",
             detail,
         )
         return result

--- a/dragonglass/server/server.py
+++ b/dragonglass/server/server.py
@@ -699,7 +699,7 @@ class DragonglassServer:
 
         return True
 
-    async def _handle_client(  # noqa: PLR0912
+    async def _handle_client(  # noqa: PLR0912, PLR0915
         self, websocket: typing.Any
     ) -> None:
         logger.info("server: client connected")
@@ -723,6 +723,18 @@ class DragonglassServer:
                 elif command == "stop":
                     if self._chat_task and not self._chat_task.done():
                         self._chat_task.cancel()
+                elif command in {"approve", "reject", "approve_session"}:
+                    request_id = str(data.get("request_id", ""))
+                    permission = str(data.get("permission", ""))
+                    if not request_id or self.agent is None:
+                        continue
+                    approved = command in {"approve", "approve_session"}
+                    self.agent.resolve_approval(
+                        request_id=request_id,
+                        approved=approved,
+                        session=(command == "approve_session"),
+                        permission=permission or None,
+                    )
                 elif command == "ping":
                     await websocket.send(json.dumps({"type": "pong"}))
                 elif command == "get_config":


### PR DESCRIPTION
This PR introduces a significant refactor of the note editing toolset and adds a "human-in-the-loop" approval mechanism for destructive operations. It also improves the Obsidian plugin lifecycle management within the macOS app.

## Major Changes

### 1. Note Editing Toolset Refactor
The monolithic `patch_note_lines` tool has been split into three targeted tools to improve agent reliability and reduce accidental overwrites:
- **`replace_lines`**: Specifically for modifying existing content.
- **`insert_after_line`**: For adding new content without touching existing lines.
- **`delete_lines`**: For explicitly removing content.

The `system_prompt.md` has been updated with clear instructions on when to use each tool, enforcing a "Read -> Identify -> Edit -> Verify" workflow.

### 2. Tool Approval Gate
To prevent the LLM from making unintended destructive changes, a new approval workflow has been implemented:
- **Backend API**: The `VaultAgent` now identifies "sensitive" tool calls (edit/delete) and emits a `FileAccessEvent` requesting permission.
- **Swift Frontend**: A new approval UI in the macOS app presents the proposed change (with a diff if applicable) to the user, requiring a manual "Approve" or "Deny" before the tool execution proceeds.
- **WebSocket Protocol**: New `approve_tool` and `deny_tool` commands allow asynchronous user confirmation.

### 3. Obsidian Plugin Lifecycle Management
- **Automatic Updates**: The Swift app now checks the version of the `dragonglass-vector-search` Obsidian plugin on startup.
- **User-Facing Prompts**: Users are now prompted to install or update the plugin if a mismatch or missing installation is detected, with a clear confirmation dialog.
- **Bundled Resources**: The plugin artifacts are now correctly bundled into the app's resources for seamless side-loading.
