### PR TITLE
fix: robust Python and Node resolution for GUI app environments

### DIFF
--- a/DragonglassApp/Dragonglass/BackendManager.swift
+++ b/DragonglassApp/Dragonglass/BackendManager.swift
@@ -393,11 +393,25 @@ class BackendManager: ObservableObject {
         let binaries = ["python3", "python3.14", "python3.13", "python3.12", "python3.11"]
         var candidatePaths = Set<String>()
 
-        // 1. Try which -a for common names
+        // 1. Try which -a for common names, with an augmented PATH
+        let extraPaths = [
+            "/opt/homebrew/bin",
+            "/opt/homebrew/sbin",
+            "/usr/local/bin",
+            "/usr/bin",
+            "/bin",
+            FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".pyenv/shims").path,
+            FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".pyenv/bin").path,
+            FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".conda/bin").path,
+        ]
+        let augmentedPath = (extraPaths + [(ProcessInfo.processInfo.environment["PATH"] ?? "")
+            .components(separatedBy: ":")]).joined(separator: ":")
+
         for bin in binaries {
             let process = Process()
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-            process.arguments = ["which", "-a", bin]
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+            process.arguments = ["-a", bin]
+            process.environment = ["PATH": augmentedPath]
             let pipe = Pipe()
             process.standardOutput = pipe
             try? process.run()
@@ -414,13 +428,21 @@ class BackendManager: ObservableObject {
             }
         }
 
-        // 2. Add some hardcoded defaults just in case
-        let defaults = [
-            "/opt/homebrew/bin/python3",
-            "/usr/local/bin/python3",
+        // 2. Add hardcoded paths covering common install locations
+        let homeDir = FileManager.default.homeDirectoryForCurrentUser
+        var defaults = [
             "/usr/bin/python3",
-            FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".conda/bin/python3").path
+            "/opt/homebrew/bin/python3",   // Apple Silicon homebrew
+            "/usr/local/bin/python3",       // Intel homebrew
+            homeDir.appendingPathComponent(".conda/bin/python3").path,
+            homeDir.appendingPathComponent(".pyenv/shims/python3").path,
         ]
+        // Versioned binaries for both homebrew prefixes
+        for bin in binaries where bin != "python3" {
+            defaults.append("/opt/homebrew/bin/\(bin)")
+            defaults.append("/usr/local/bin/\(bin)")
+            defaults.append(homeDir.appendingPathComponent(".pyenv/shims/\(bin)").path)
+        }
         candidatePaths.formUnion(defaults)
 
         var candidates: [(path: String, version: String)] = []

--- a/DragonglassApp/Dragonglass/BackendManager.swift
+++ b/DragonglassApp/Dragonglass/BackendManager.swift
@@ -404,8 +404,8 @@ class BackendManager: ObservableObject {
             FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".pyenv/bin").path,
             FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".conda/bin").path,
         ]
-        let augmentedPath = (extraPaths + [(ProcessInfo.processInfo.environment["PATH"] ?? "")
-            .components(separatedBy: ":")]).joined(separator: ":")
+        let augmentedPath = (extraPaths + (ProcessInfo.processInfo.environment["PATH"] ?? "")
+            .components(separatedBy: ":")).joined(separator: ":")
 
         for bin in binaries {
             let process = Process()
@@ -652,8 +652,8 @@ class BackendManager: ObservableObject {
             homeDir.appendingPathComponent(".volta/bin").path,
             homeDir.appendingPathComponent(".fnm").path,
         ]
-        let augmentedPath = (extraPaths + [(ProcessInfo.processInfo.environment["PATH"] ?? "")
-            .components(separatedBy: ":")]).joined(separator: ":")
+        let augmentedPath = (extraPaths + (ProcessInfo.processInfo.environment["PATH"] ?? "")
+            .components(separatedBy: ":")).joined(separator: ":")
 
         // which -a to collect all npm binaries on the augmented PATH
         let process = Process()

--- a/DragonglassApp/Dragonglass/BackendManager.swift
+++ b/DragonglassApp/Dragonglass/BackendManager.swift
@@ -640,28 +640,59 @@ class BackendManager: ObservableObject {
     }
 
     private func findNpm() -> String? {
-        let candidates = [
+        let homeDir = FileManager.default.homeDirectoryForCurrentUser
+
+        // Augment PATH so which can find node version manager installs
+        let extraPaths = [
+            "/opt/homebrew/bin",
+            "/opt/homebrew/sbin",
+            "/usr/local/bin",
+            "/usr/bin",
+            "/bin",
+            homeDir.appendingPathComponent(".volta/bin").path,
+            homeDir.appendingPathComponent(".fnm").path,
+        ]
+        let augmentedPath = (extraPaths + [(ProcessInfo.processInfo.environment["PATH"] ?? "")
+            .components(separatedBy: ":")]).joined(separator: ":")
+
+        // which -a to collect all npm binaries on the augmented PATH
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+        process.arguments = ["-a", "npm"]
+        process.environment = ["PATH": augmentedPath]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        try? process.run()
+        process.waitUntilExit()
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        if let output = String(data: data, encoding: .utf8) {
+            let found = output.components(separatedBy: .newlines)
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+            if let first = found.first {
+                return first
+            }
+        }
+
+        // Hardcoded fallbacks including nvm (pick the highest node version available)
+        var hardcoded = [
             "/opt/homebrew/bin/npm",
             "/usr/local/bin/npm",
             "/usr/bin/npm",
-            "npm"
+            homeDir.appendingPathComponent(".volta/bin/npm").path,
         ]
-        for candidate in candidates {
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-            process.arguments = ["which", candidate]
-            let pipe = Pipe()
-            process.standardOutput = pipe
-            try? process.run()
-            process.waitUntilExit()
-            if process.terminationStatus == 0 {
-                let data = pipe.fileHandleForReading.readDataToEndOfFile()
-                if let output = String(data: data, encoding: .utf8) {
-                    let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
-                    if !trimmed.isEmpty {
-                        return trimmed
-                    }
-                }
+        // nvm: glob for installed node versions, pick the last (typically highest)
+        let nvmBase = homeDir.appendingPathComponent(".nvm/versions/node")
+        if let versions = try? FileManager.default.contentsOfDirectory(atPath: nvmBase.path).sorted() {
+            for v in versions.reversed() {
+                hardcoded.insert(nvmBase.appendingPathComponent("\(v)/bin/npm").path, at: 0)
+            }
+        }
+
+        for candidate in hardcoded {
+            if FileManager.default.fileExists(atPath: candidate) {
+                return candidate
             }
         }
         return nil

--- a/DragonglassApp/Dragonglass/BackendManager.swift
+++ b/DragonglassApp/Dragonglass/BackendManager.swift
@@ -448,23 +448,59 @@ class BackendManager: ObservableObject {
             }
         }
 
-        // Sort candidates by version (descending)
-        candidates.sort { a, b in
-            let va = a.version.split(separator: ".").compactMap { Int($0) }
-            let vb = b.version.split(separator: ".").compactMap { Int($0) }
-            for i in 0..<min(va.count, vb.count) {
-                if va[i] != vb[i] { return va[i] > vb[i] }
+        if candidates.isEmpty {
+            print("[BackendManager] No compatible Python 3.11+ found, falling back to /usr/bin/python3")
+            return "/usr/bin/python3"
+        }
+
+        // Build a lookup: minor version → best path for that version
+        var byMinor: [Int: (path: String, version: String)] = [:]
+        for c in candidates {
+            let parts = c.version.split(separator: ".").compactMap { Int($0) }
+            guard parts.count >= 2 else { continue }
+            let minor = parts[1]
+            if byMinor[minor] == nil {
+                byMinor[minor] = c
             }
-            return va.count > vb.count
         }
 
-        if let best = candidates.first {
-            print("[BackendManager] Selected \(best.path) (highest compatible version \(best.version))")
-            return best.path
+        // Determine the bundled minor version as the preferred starting point
+        let bundledMinor: Int
+        if let required = requiredVersion,
+           let m = required.split(separator: ".").compactMap({ Int($0) }).dropFirst().first {
+            bundledMinor = m
+        } else {
+            bundledMinor = 11
         }
 
-        print("[BackendManager] No compatible Python 3.11+ found, falling back to /usr/bin/python3")
-        return "/usr/bin/python3"
+        let supportedMinors = binaries.compactMap { bin -> Int? in
+            guard bin.hasPrefix("python3."), let m = Int(bin.dropFirst("python3.".count)) else { return nil }
+            return m
+        }
+        let minMinor = supportedMinors.min() ?? bundledMinor
+        let maxMinor = byMinor.keys.max() ?? bundledMinor
+
+        // Search order: same → up → down (all relative to bundledMinor, within [minMinor, maxMinor])
+        var searchOrder: [Int] = [bundledMinor]
+        let upperBound = max(bundledMinor, maxMinor)
+        for v in (bundledMinor + 1)...max(bundledMinor + 1, upperBound) {
+            searchOrder.append(v)
+        }
+        for v in stride(from: bundledMinor - 1, through: minMinor, by: -1) {
+            searchOrder.append(v)
+        }
+
+        for minor in searchOrder {
+            if let match = byMinor[minor] {
+                print("[BackendManager] Selected \(match.path) (version \(match.version), bundled minor was \(bundledMinor))")
+                return match.path
+            }
+        }
+
+        // Shouldn't reach here, but just in case
+        let best = candidates.first!
+        print("[BackendManager] Selected \(best.path) (fallback, version \(best.version))")
+        return best.path
     }
 
     private func getPythonVersion(at path: String) -> String? {


### PR DESCRIPTION
## Summary

macOS GUI apps launch with a minimal `PATH` that doesn't include user shell customisations from `.zprofile`/`.zshrc`, so `which` was failing to find Python and npm installed via homebrew, pyenv, nvm, volta, etc.

- Python selection now runs `which -a` with an augmented `PATH` (homebrew M1/Intel, pyenv shims, conda) and also probes versioned hardcoded paths (`/opt/homebrew/bin/python3.12`, etc.)
- Python version preference order: exact match with bundled wheels → same minor → newer minors → older minors down to the minimum supported version. Min supported version is derived from the `binaries` array, not hardcoded.
- npm resolution gets the same augmented-PATH treatment, plus hardcoded fallbacks for volta and nvm (picks highest installed node version).
