### PR TITLE
fix: microphone access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ node_modules/
 # Swift / Xcode
 DerivedData/
 **/.derived-data*
+**/xcuserdata/
 /*.xcworkspace
 *.xcuserstate
 DragonglassApp/Resources/wheels/

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ node_modules/
 
 # Swift / Xcode
 DerivedData/
+**/.derived-data*
 /*.xcworkspace
 *.xcuserstate
 DragonglassApp/Resources/wheels/

--- a/DragonglassApp/Dragonglass.xcodeproj/project.pbxproj
+++ b/DragonglassApp/Dragonglass.xcodeproj/project.pbxproj
@@ -294,6 +294,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Dragonglass/Dragonglass.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
@@ -332,6 +333,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Dragonglass/Dragonglass.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
@@ -389,20 +391,20 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		29D2027E2F78014200A0B14C /* XCRemoteSwiftPackageReference "whisperkit" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/argmaxinc/whisperkit";
-			requirement = {
-				kind = exactVersion;
-				version = 0.17.0;
-			};
-		};
 		29D201F12F775B0400A0B14C /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SimplyDanny/SwiftLintPlugins";
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 0.63.2;
+			};
+		};
+		29D2027E2F78014200A0B14C /* XCRemoteSwiftPackageReference "whisperkit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/argmaxinc/whisperkit";
+			requirement = {
+				kind = exactVersion;
+				version = 0.17.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/DragonglassApp/Dragonglass.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/DragonglassApp/Dragonglass.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -2,10 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>BuildSystemType</key>
-	<string>Latest</string>
 	<key>BuildLocationStyle</key>
 	<string>Default</string>
+	<key>BuildSystemType</key>
+	<string>Latest</string>
 	<key>DerivedDataLocationStyle</key>
 	<string>Default</string>
 </dict>

--- a/DragonglassApp/Dragonglass.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DragonglassApp/Dragonglass.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8f61689e55c5551e76f2c686d145061dc1fa621a58cbca576565ebfabc15c894",
+  "originHash" : "7bfe2c38c66cbc28afca00f2feac9bf1679ed182b75b95408427eb23595dba67",
   "pins" : [
     {
       "identity" : "swift-argument-parser",
@@ -53,6 +53,15 @@
       "state" : {
         "revision" : "150169bfba0889c229a2ce7494cf8949f18e6906",
         "version" : "1.1.9"
+      }
+    },
+    {
+      "identity" : "swiftlintplugins",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SimplyDanny/SwiftLintPlugins",
+      "state" : {
+        "revision" : "8a4640d14777685ba8f14e832373160498fbab92",
+        "version" : "0.63.2"
       }
     },
     {

--- a/DragonglassApp/Dragonglass/BackendManager.swift
+++ b/DragonglassApp/Dragonglass/BackendManager.swift
@@ -18,7 +18,7 @@ enum BackendPhase: Equatable {
 @MainActor
 class BackendManager: ObservableObject {
     @Published var phase: BackendPhase = .starting
-    @Published var obsidianWarning: String? = nil
+    @Published var obsidianWarning: String?
     private var process: Process?
     private var obsidianPollTask: Task<Void, Never>?
 
@@ -421,7 +421,7 @@ class BackendManager: ObservableObject {
             "/bin",
             FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".pyenv/shims").path,
             FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".pyenv/bin").path,
-            FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".conda/bin").path,
+            FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".conda/bin").path
         ]
         let augmentedPath = (extraPaths + (ProcessInfo.processInfo.environment["PATH"] ?? "")
             .components(separatedBy: ":")).joined(separator: ":")
@@ -454,7 +454,7 @@ class BackendManager: ObservableObject {
             "/opt/homebrew/bin/python3",   // Apple Silicon homebrew
             "/usr/local/bin/python3",       // Intel homebrew
             homeDir.appendingPathComponent(".conda/bin/python3").path,
-            homeDir.appendingPathComponent(".pyenv/shims/python3").path,
+            homeDir.appendingPathComponent(".pyenv/shims/python3").path
         ]
         // Versioned binaries for both homebrew prefixes
         for bin in binaries where bin != "python3" {
@@ -669,7 +669,7 @@ class BackendManager: ObservableObject {
             "/usr/bin",
             "/bin",
             homeDir.appendingPathComponent(".volta/bin").path,
-            homeDir.appendingPathComponent(".fnm").path,
+            homeDir.appendingPathComponent(".fnm").path
         ]
         let augmentedPath = (extraPaths + (ProcessInfo.processInfo.environment["PATH"] ?? "")
             .components(separatedBy: ":")).joined(separator: ":")
@@ -699,7 +699,7 @@ class BackendManager: ObservableObject {
             "/opt/homebrew/bin/npm",
             "/usr/local/bin/npm",
             "/usr/bin/npm",
-            homeDir.appendingPathComponent(".volta/bin/npm").path,
+            homeDir.appendingPathComponent(".volta/bin/npm").path
         ]
         // nvm: glob for installed node versions, pick the last (typically highest)
         let nvmBase = homeDir.appendingPathComponent(".nvm/versions/node")

--- a/DragonglassApp/Dragonglass/ContentView.swift
+++ b/DragonglassApp/Dragonglass/ContentView.swift
@@ -689,9 +689,13 @@ struct MicButton: View {
                     sttManager.stopAndTranscribe()
                 }
         )
-        .disabled(!sttManager.micPermissionGranted || client.isThinking)
-        .opacity(sttManager.micPermissionGranted ? 1.0 : 0.3)
-        .help(sttManager.micPermissionGranted ? "Hold to dictate" : "Microphone permission required")
+        .disabled(!sttManager.micPermissionGranted || !sttManager.isModelReady || client.isThinking)
+        .opacity(sttManager.micPermissionGranted && sttManager.isModelReady ? 1.0 : 0.3)
+        .help(
+            !sttManager.micPermissionGranted ? "Microphone permission required" :
+            !sttManager.isModelReady ? "Download a Whisper model in Settings first" :
+            "Hold to dictate"
+        )
     }
 }
 

--- a/DragonglassApp/Dragonglass/Dragonglass.entitlements
+++ b/DragonglassApp/Dragonglass/Dragonglass.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
+</dict>
+</plist>

--- a/DragonglassApp/Dragonglass/KeyRecorderView.swift
+++ b/DragonglassApp/Dragonglass/KeyRecorderView.swift
@@ -53,7 +53,7 @@ class KeyRecorderNSView: NSView {
         let text = displayString()
         let attrs: [NSAttributedString.Key: Any] = [
             .font: NSFont.systemFont(ofSize: 12),
-            .foregroundColor: isRecording ? NSColor.controlAccentColor : NSColor.labelColor,
+            .foregroundColor: isRecording ? NSColor.controlAccentColor : NSColor.labelColor
         ]
         let str = NSAttributedString(string: text, attributes: attrs)
         let size = str.size()
@@ -104,7 +104,7 @@ class KeyRecorderNSView: NSView {
             123: "←", 124: "→", 125: "↓", 126: "↑",
             122: "F1", 120: "F2", 99: "F3", 118: "F4", 96: "F5",
             97: "F6", 98: "F7", 100: "F8", 101: "F9", 109: "F10",
-            103: "F11", 111: "F12",
+            103: "F11", 111: "F12"
         ]
         if let name = named[keyCode] { return name }
         if let char = characterForKeyCode(UInt16(keyCode)) { return char.uppercased() }

--- a/DragonglassApp/Dragonglass/STTManager.swift
+++ b/DragonglassApp/Dragonglass/STTManager.swift
@@ -1,6 +1,9 @@
 import AVFoundation
 import Combine
 import WhisperKit
+import os
+
+private let logger = Logger(subsystem: "com.antolu.dragonglass", category: "STTManager")
 
 @MainActor
 final class STTManager: ObservableObject {
@@ -35,8 +38,16 @@ final class STTManager: ObservableObject {
     private var audioSamples: [Float] = []
     private var converter: AVAudioConverter?
     private var autoSendTask: Task<Void, Never>?
+    private let audioQueue = DispatchQueue(label: "com.antolu.dragonglass.audio", qos: .userInteractive)
+
+    private final class AudioBuffer: @unchecked Sendable {
+        var samples: [Float] = []
+        var tapCount: Int = 0
+    }
+    private let audioBuffer = AudioBuffer()
 
     init() {
+        logger.debug("Initializing STTManager")
         checkMicPermission()
         checkAccessibilityPermission()
         refreshLocalModels()
@@ -69,14 +80,16 @@ final class STTManager: ObservableObject {
 
     var modelRepoPath: String {
         URL(fileURLWithPath: localModelPath)
-            .appendingPathComponent("argmaxinc/whisperkit-coreml")
+            .appendingPathComponent("models/argmaxinc/whisperkit-coreml")
             .path
     }
 
     func refreshLocalModels() {
         try? FileManager.default.createDirectory(atPath: modelRepoPath, withIntermediateDirectories: true)
         let contents = (try? FileManager.default.contentsOfDirectory(atPath: modelRepoPath)) ?? []
-        localModels = ModelUtilities.formatModelFiles(contents)
+        // Using raw folder names ensures it matches what downloadModel/WhisperKit uses.
+        localModels = contents
+        logger.debug("Refreshed local models: \(contents)")
     }
 
     func fetchAvailableModels() async {
@@ -90,6 +103,7 @@ final class STTManager: ObservableObject {
 
     func downloadModel(_ modelName: String) {
         guard downloadProgress[modelName] == nil else { return }
+        logger.info("Starting download for model: \(modelName)")
         downloadProgress[modelName] = 0.0
         let downloadBase = URL(fileURLWithPath: localModelPath)
         Task {
@@ -104,6 +118,7 @@ final class STTManager: ObservableObject {
                         }
                     }
                 )
+                logger.info("Download completed for: \(modelName)")
                 await MainActor.run {
                     self.downloadProgress.removeValue(forKey: modelName)
                     self.refreshLocalModels()
@@ -115,6 +130,7 @@ final class STTManager: ObservableObject {
                     }
                 }
             } catch {
+                logger.error("Download failed for \(modelName): \(error.localizedDescription)")
                 let name = modelName
                 await MainActor.run { _ = self.downloadProgress.removeValue(forKey: name) }
             }
@@ -132,6 +148,7 @@ final class STTManager: ObservableObject {
 
     func switchModel(to modelName: String) {
         guard modelName != selectedModel else { return }
+        logger.info("Switching model to: \(modelName)")
         objectWillChange.send()
         selectedModel = modelName
         loadTask?.cancel()
@@ -144,17 +161,31 @@ final class STTManager: ObservableObject {
     // MARK: - WhisperKit loading
 
     private func ensureLoaded() async throws {
-        if whisperKit != nil { return }
+        if let wk = whisperKit {
+            logger.debug("Model already loaded: \(wk.modelVariant)")
+            return
+        }
         if let task = loadTask {
+            logger.debug("Awaiting existing load task")
             whisperKit = try await task.value
             return
         }
         let model = selectedModel.isEmpty ? "openai_whisper-large-v3-v20240930_turbo" : selectedModel
         let repoURL = URL(fileURLWithPath: modelRepoPath)
+        let modelFolder = repoURL.appendingPathComponent(model)
+
+        logger.info("Initializing WhisperKit with model: \(model)")
+        logger.debug("Model folder: \(modelFolder.path)")
+
+        guard FileManager.default.fileExists(atPath: modelFolder.path) else {
+            logger.warning("Model folder does not exist: \(modelFolder.path)")
+            throw STTError.notDownloaded
+        }
+
         let config = WhisperKitConfig(
             model: model,
             downloadBase: URL(fileURLWithPath: localModelPath),
-            modelFolder: repoURL.appendingPathComponent(model).path,
+            modelFolder: modelFolder.path,
             load: true,
             download: false
         )
@@ -165,13 +196,23 @@ final class STTManager: ObservableObject {
             loadTask = nil
             isModelLoading = false
         }
-        whisperKit = try await task.value
+        do {
+            whisperKit = try await task.value
+            logger.info("WhisperKit loaded successfully")
+        } catch {
+            logger.error("Failed to load WhisperKit: \(error.localizedDescription)")
+            throw error
+        }
     }
 
     // MARK: - Recording
 
     func startRecording() {
-        guard !isRecording, micPermissionGranted, isModelReady else { return }
+        guard !isRecording, micPermissionGranted, isModelReady else {
+            logger.warning("startRecording failed: isRecording=\(self.isRecording), micGranted=\(self.micPermissionGranted), isModelReady=\(self.isModelReady)")
+            return
+        }
+        logger.info("Starting recording...")
         autoSendTask?.cancel()
         autoSendTask = nil
         pendingText = nil
@@ -182,7 +223,11 @@ final class STTManager: ObservableObject {
             audioEngine = AVAudioEngine()
             let inputNode = audioEngine.inputNode
             let hwFormat = inputNode.inputFormat(forBus: 0)
-            guard hwFormat.sampleRate > 0, hwFormat.channelCount > 0 else { return }
+            logger.debug("Input format: \(hwFormat)")
+            guard hwFormat.sampleRate > 0, hwFormat.channelCount > 0 else {
+                logger.error("Invalid hardware format: rate=\(hwFormat.sampleRate), channels=\(hwFormat.channelCount)")
+                return
+            }
             let targetFormat = AVAudioFormat(
                 commonFormat: .pcmFormatFloat32,
                 sampleRate: 16000,
@@ -211,49 +256,72 @@ final class STTManager: ObservableObject {
                 guard error == nil, converted.frameLength > 0 else { return }
                 let count = Int(converted.frameLength)
                 let samples = Array(UnsafeBufferPointer(start: channelData[0], count: count))
-                DispatchQueue.main.async { self.audioSamples.append(contentsOf: samples) }
+                self.audioQueue.async {
+                    self.audioBuffer.samples.append(contentsOf: samples)
+                    self.audioBuffer.tapCount += 1
+                    if self.audioBuffer.tapCount % 50 == 0 {
+                        logger.debug("Accumulated \(self.audioBuffer.samples.count) samples (tap #\(self.audioBuffer.tapCount))")
+                    }
+                }
             }
 
             try audioEngine.start()
             isRecording = true
+            audioQueue.async { self.audioBuffer.tapCount = 0 }
+            logger.info("Recording started successfully")
         } catch {
+            logger.error("audioEngine.start error: \(error.localizedDescription)")
             print("[STTManager] startRecording error: \(error)")
         }
     }
 
     func stopAndTranscribe() {
         guard isRecording else { return }
+        logger.info("Stopping recording and starting transcription")
         audioEngine.inputNode.removeTap(onBus: 0)
         audioEngine.stop()
         isRecording = false
 
-        let samples = audioSamples
-        audioSamples = []
-        guard !samples.isEmpty else { return }
+        audioQueue.sync {
+            let samples = audioBuffer.samples
+            audioBuffer.samples = []
+            let currentTapCount = audioBuffer.tapCount
+            audioBuffer.tapCount = 0
+            logger.debug("Captured \(samples.count) samples (tap count: \(currentTapCount))")
+
+            Task { @MainActor in
+                await self.performTranscription(with: samples)
+            }
+        }
+    }
+
+    private func performTranscription(with samples: [Float]) async {
+        guard !samples.isEmpty else {
+            logger.warning("No samples captured, skipping transcription")
+            return
+        }
 
         isTranscribing = true
-        Task {
-            do {
-                try await ensureLoaded()
-                guard let wk = whisperKit else { throw STTError.notLoaded }
-                let results = await wk.transcribe(audioArrays: [samples])
-                let text = results
-                    .compactMap { $0?.first?.text }
-                    .joined(separator: " ")
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
-                await MainActor.run {
-                    self.isTranscribing = false
-                    guard !text.isEmpty else { return }
-                    self.pendingText = text
-                    if self.autoSend {
-                        self.scheduleAutoSend()
-                    }
-                }
-            } catch {
-                await MainActor.run {
-                    self.isTranscribing = false
-                }
+        do {
+            try await ensureLoaded()
+            guard let wk = whisperKit else { throw STTError.notLoaded }
+            logger.debug("Calling WhisperKit.transcribe")
+            let results = await wk.transcribe(audioArrays: [samples])
+            let text = results
+                .compactMap { $0?.first?.text }
+                .joined(separator: " ")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            logger.info("Transcription result: \"\(text)\"")
+
+            self.isTranscribing = false
+            guard !text.isEmpty else { return }
+            self.pendingText = text
+            if self.autoSend {
+                self.scheduleAutoSend()
             }
+        } catch {
+            logger.error("Transcription failed: \(error.localizedDescription)")
+            self.isTranscribing = false
         }
     }
 
@@ -283,4 +351,5 @@ final class STTManager: ObservableObject {
 
 enum STTError: Error {
     case notLoaded
+    case notDownloaded
 }

--- a/DragonglassApp/Dragonglass/STTManager.swift
+++ b/DragonglassApp/Dragonglass/STTManager.swift
@@ -6,6 +6,7 @@ import WhisperKit
 final class STTManager: ObservableObject {
     @Published var isRecording = false
     @Published var isTranscribing = false
+    @Published var isModelLoading = false
     @Published var pendingText: String?
     @Published var readyToFire = false
     @Published var downloadProgress: [String: Double] = [:]
@@ -27,6 +28,7 @@ final class STTManager: ObservableObject {
     private static let repoName = "argmaxinc/whisperkit-coreml"
 
     private var whisperKit: WhisperKit?
+    private var loadTask: Task<WhisperKit, Error>?
     private var audioEngine: AVAudioEngine!
     private var audioSamples: [Float] = []
     private var converter: AVAudioConverter?
@@ -37,6 +39,7 @@ final class STTManager: ObservableObject {
         checkAccessibilityPermission()
         refreshLocalModels()
         Task { await fetchAvailableModels() }
+        Task { try? await ensureLoaded() }
     }
 
     // MARK: - Permissions
@@ -98,7 +101,10 @@ final class STTManager: ObservableObject {
                     self.downloadProgress.removeValue(forKey: modelName)
                     self.refreshLocalModels()
                     if self.selectedModel == modelName {
+                        self.loadTask?.cancel()
+                        self.loadTask = nil
                         self.whisperKit = nil
+                        Task { try? await self.ensureLoaded() }
                     }
                 }
             } catch {
@@ -120,14 +126,21 @@ final class STTManager: ObservableObject {
     func switchModel(to modelName: String) {
         guard modelName != selectedModel else { return }
         selectedModel = modelName
+        loadTask?.cancel()
+        loadTask = nil
         Task { await self.whisperKit?.unloadModels() }
         whisperKit = nil
+        Task { try? await ensureLoaded() }
     }
 
     // MARK: - WhisperKit loading
 
     private func ensureLoaded() async throws {
-        guard whisperKit == nil else { return }
+        if whisperKit != nil { return }
+        if let task = loadTask {
+            whisperKit = try await task.value
+            return
+        }
         let model = selectedModel.isEmpty ? "openai_whisper-large-v3" : selectedModel
         let base = URL(fileURLWithPath: localModelPath)
         let config = WhisperKitConfig(
@@ -137,7 +150,14 @@ final class STTManager: ObservableObject {
             load: true,
             download: false
         )
-        whisperKit = try await WhisperKit(config)
+        let task = Task<WhisperKit, Error> { try await WhisperKit(config) }
+        loadTask = task
+        isModelLoading = true
+        defer {
+            loadTask = nil
+            isModelLoading = false
+        }
+        whisperKit = try await task.value
     }
 
     // MARK: - Recording
@@ -153,8 +173,8 @@ final class STTManager: ObservableObject {
         do {
             audioEngine = AVAudioEngine()
             let inputNode = audioEngine.inputNode
-            let hwFormat = inputNode.outputFormat(forBus: 0)
-            guard hwFormat.sampleRate > 0 else { return }
+            let hwFormat = inputNode.inputFormat(forBus: 0)
+            guard hwFormat.sampleRate > 0, hwFormat.channelCount > 0 else { return }
             let targetFormat = AVAudioFormat(
                 commonFormat: .pcmFormatFloat32,
                 sampleRate: 16000,
@@ -169,17 +189,21 @@ final class STTManager: ObservableObject {
                 let outFrames = AVAudioFrameCount(Double(buffer.frameLength) * ratio + 1)
                 guard let converted = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: outFrames),
                       let channelData = converted.floatChannelData else { return }
+                var done = false
                 var error: NSError?
-                let inputBlock: AVAudioConverterInputBlock = { _, outStatus in
+                converter.convert(to: converted, error: &error) { _, outStatus in
+                    if done {
+                        outStatus.pointee = .endOfStream
+                        return nil
+                    }
+                    done = true
                     outStatus.pointee = .haveData
                     return buffer
                 }
-                converter.convert(to: converted, error: &error, withInputFrom: inputBlock)
-                if error == nil {
-                    let count = Int(converted.frameLength)
-                    let samples = Array(UnsafeBufferPointer(start: channelData[0], count: count))
-                    DispatchQueue.main.async { self.audioSamples.append(contentsOf: samples) }
-                }
+                guard error == nil, converted.frameLength > 0 else { return }
+                let count = Int(converted.frameLength)
+                let samples = Array(UnsafeBufferPointer(start: channelData[0], count: count))
+                DispatchQueue.main.async { self.audioSamples.append(contentsOf: samples) }
             }
 
             try audioEngine.start()

--- a/DragonglassApp/Dragonglass/STTManager.swift
+++ b/DragonglassApp/Dragonglass/STTManager.swift
@@ -87,9 +87,10 @@ final class STTManager: ObservableObject {
     func refreshLocalModels() {
         try? FileManager.default.createDirectory(atPath: modelRepoPath, withIntermediateDirectories: true)
         let contents = (try? FileManager.default.contentsOfDirectory(atPath: modelRepoPath)) ?? []
-        // Using raw folder names ensures it matches what downloadModel/WhisperKit uses.
-        localModels = contents
-        logger.debug("Refreshed local models: \(contents)")
+        // Only include non-hidden directories (ignore .cache, etc.)
+        let models = contents.filter { !$0.hasPrefix(".") }
+        localModels = models
+        logger.debug("Refreshed local models: \(models)")
     }
 
     func fetchAvailableModels() async {

--- a/DragonglassApp/Dragonglass/STTManager.swift
+++ b/DragonglassApp/Dragonglass/STTManager.swift
@@ -16,9 +16,11 @@ final class STTManager: ObservableObject {
     @Published var accessibilityGranted = false
 
     var selectedModel: String {
-        get { UserDefaults.standard.string(forKey: "sttSelectedModel") ?? "openai_whisper-large-v3" }
+        get { UserDefaults.standard.string(forKey: "sttSelectedModel") ?? "openai_whisper-large-v3-v20240930_turbo" }
         set { UserDefaults.standard.set(newValue, forKey: "sttSelectedModel") }
     }
+
+    var isModelReady: Bool { localModels.contains(selectedModel) }
 
     var autoSend: Bool {
         get { UserDefaults.standard.object(forKey: "sttAutoSend") as? Bool ?? true }
@@ -65,10 +67,15 @@ final class STTManager: ObservableObject {
         return appSupport.appendingPathComponent("dragonglass/whisperkit-models").path
     }
 
+    var modelRepoPath: String {
+        URL(fileURLWithPath: localModelPath)
+            .appendingPathComponent("argmaxinc/whisperkit-coreml")
+            .path
+    }
+
     func refreshLocalModels() {
-        let path = localModelPath
-        try? FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true)
-        let contents = (try? FileManager.default.contentsOfDirectory(atPath: path)) ?? []
+        try? FileManager.default.createDirectory(atPath: modelRepoPath, withIntermediateDirectories: true)
+        let contents = (try? FileManager.default.contentsOfDirectory(atPath: modelRepoPath)) ?? []
         localModels = ModelUtilities.formatModelFiles(contents)
     }
 
@@ -115,7 +122,7 @@ final class STTManager: ObservableObject {
     }
 
     func deleteModel(_ modelName: String) {
-        let folderURL = URL(fileURLWithPath: localModelPath).appendingPathComponent(modelName)
+        let folderURL = URL(fileURLWithPath: modelRepoPath).appendingPathComponent(modelName)
         try? FileManager.default.removeItem(at: folderURL)
         if selectedModel == modelName {
             whisperKit = nil
@@ -125,6 +132,7 @@ final class STTManager: ObservableObject {
 
     func switchModel(to modelName: String) {
         guard modelName != selectedModel else { return }
+        objectWillChange.send()
         selectedModel = modelName
         loadTask?.cancel()
         loadTask = nil
@@ -141,12 +149,12 @@ final class STTManager: ObservableObject {
             whisperKit = try await task.value
             return
         }
-        let model = selectedModel.isEmpty ? "openai_whisper-large-v3" : selectedModel
-        let base = URL(fileURLWithPath: localModelPath)
+        let model = selectedModel.isEmpty ? "openai_whisper-large-v3-v20240930_turbo" : selectedModel
+        let repoURL = URL(fileURLWithPath: modelRepoPath)
         let config = WhisperKitConfig(
             model: model,
-            downloadBase: base,
-            modelFolder: base.appendingPathComponent(model).path,
+            downloadBase: URL(fileURLWithPath: localModelPath),
+            modelFolder: repoURL.appendingPathComponent(model).path,
             load: true,
             download: false
         )
@@ -163,7 +171,7 @@ final class STTManager: ObservableObject {
     // MARK: - Recording
 
     func startRecording() {
-        guard !isRecording, micPermissionGranted else { return }
+        guard !isRecording, micPermissionGranted, isModelReady else { return }
         autoSendTask?.cancel()
         autoSendTask = nil
         pendingText = nil

--- a/DragonglassApp/Dragonglass/STTManager.swift
+++ b/DragonglassApp/Dragonglass/STTManager.swift
@@ -27,7 +27,7 @@ final class STTManager: ObservableObject {
     private static let repoName = "argmaxinc/whisperkit-coreml"
 
     private var whisperKit: WhisperKit?
-    private var audioEngine = AVAudioEngine()
+    private var audioEngine: AVAudioEngine!
     private var audioSamples: [Float] = []
     private var converter: AVAudioConverter?
     private var autoSendTask: Task<Void, Never>?
@@ -45,11 +45,9 @@ final class STTManager: ObservableObject {
         micPermissionGranted = AVAudioApplication.shared.recordPermission == .granted
     }
 
-    func requestMicPermission() {
-        Task {
-            let granted = await AVAudioApplication.requestRecordPermission()
-            micPermissionGranted = granted
-        }
+    func requestMicPermission() async {
+        let granted = await AVAudioApplication.requestRecordPermission()
+        micPermissionGranted = granted
     }
 
     func checkAccessibilityPermission() {
@@ -156,6 +154,7 @@ final class STTManager: ObservableObject {
             audioEngine = AVAudioEngine()
             let inputNode = audioEngine.inputNode
             let hwFormat = inputNode.outputFormat(forBus: 0)
+            guard hwFormat.sampleRate > 0 else { return }
             let targetFormat = AVAudioFormat(
                 commonFormat: .pcmFormatFloat32,
                 sampleRate: 16000,

--- a/DragonglassApp/Dragonglass/SpeechSettingsView.swift
+++ b/DragonglassApp/Dragonglass/SpeechSettingsView.swift
@@ -31,41 +31,33 @@ struct SpeechSettingsView: View {
 
             Divider()
 
-            if !sttManager.localModels.isEmpty {
-                HStack {
-                    Text("Active model")
-                        .font(.caption)
-                    Spacer()
-                    Picker("", selection: Binding(
-                        get: { sttManager.selectedModel },
-                        set: { sttManager.switchModel(to: $0) }
-                    )) {
-                        ForEach(sttManager.localModels, id: \.self) { m in
-                            Text(m).tag(m)
-                        }
-                    }
-                    .labelsHidden()
-                    .fixedSize()
+            HStack {
+                Text("Whisper model")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                Spacer()
+                if sttManager.isModelLoading {
+                    ProgressView()
+                        .scaleEffect(0.6)
+                        .frame(height: 14)
+                    Text("Loading…")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
                 }
             }
 
-            DisclosureGroup("Manage models") {
-                if sttManager.availableModels.isEmpty {
-                    ProgressView("Loading…")
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.top, 4)
-                } else {
-                    VStack(spacing: 2) {
-                        ForEach(sttManager.availableModels, id: \.self) { model in
-                            ModelRowView(modelName: model)
-                                .environmentObject(sttManager)
-                        }
+            if sttManager.availableModels.isEmpty {
+                ProgressView("Fetching model list…")
+                    .font(.caption)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else {
+                VStack(spacing: 2) {
+                    ForEach(sttManager.availableModels, id: \.self) { model in
+                        ModelRowView(modelName: model)
+                            .environmentObject(sttManager)
                     }
-                    .padding(.top, 4)
                 }
             }
-            .font(.caption)
-            .foregroundColor(.secondary)
         }
         .onAppear {
             sttManager.refreshLocalModels()
@@ -187,7 +179,7 @@ struct ModelRowView: View {
     }
 
     private func diskSize() -> String {
-        let folder = URL(fileURLWithPath: sttManager.localModelPath).appendingPathComponent(modelName)
+        let folder = URL(fileURLWithPath: sttManager.modelRepoPath).appendingPathComponent(modelName)
         guard let enumerator = FileManager.default.enumerator(
             at: folder,
             includingPropertiesForKeys: [.fileSizeKey],

--- a/DragonglassApp/Dragonglass/SpeechSettingsView.swift
+++ b/DragonglassApp/Dragonglass/SpeechSettingsView.swift
@@ -83,7 +83,7 @@ struct SpeechSettingsView: View {
                 .font(.caption)
             Spacer()
             if !sttManager.micPermissionGranted {
-                Button("Grant") { sttManager.requestMicPermission() }
+                Button("Grant") { Task { await sttManager.requestMicPermission() } }
                     .buttonStyle(.plain)
                     .foregroundColor(.accentColor)
                     .font(.caption)


### PR DESCRIPTION
This PR addresses several issues regarding the WhisperKit integration, audio recording reliability, and project-level entitlements for microphone access in the Dragonglass macOS app.

## Summary of Changes

### Audio Recording and WhisperKit
- **Recording Pipeline Overhaul** (0cd1d75): Improved the thread-safety and reliability of the [STTManager.swift](DragonglassApp/Dragonglass/STTManager.swift) recording pipeline. 
- **Audio Converter Fixes** (5026252): Resolved issues in the audio converter block that caused recording failures.
- **Model Discovery Logic** (0f58bb9, 3e5a38d): Enhanced the model discovery mechanism in [STTManager.swift](DragonglassApp/Dragonglass/STTManager.swift) to correctly handle disk size calculations and filter out hidden directories (e.g., .cache) during path resolution.
- **Initialization Refinement** (ac2166b): Deferred AVAudioEngine initialization to ensure proper setup before usage.

### Permissions and Security
- **Microphone Entitlements** (37d8611): Added the mandatory `com.apple.security.device.audio-input` entitlement to [Dragonglass.entitlements](DragonglassApp/Dragonglass.entitlements).
- **Privacy Strings** (37d8611): Included `NSMicrophoneUsageDescription` in [Info.plist](DragonglassApp/Dragonglass/Info.plist) to properly request user permission for audio recording.

### Project Configuration and Maintenance
- **Improved Git Hygiene** (32b8dcc, 7a64071): Updated [.gitignore](.gitignore) to better exclude Xcode-generated files like DerivedData and xuserdata.
- **Workspace and Package Resolution** (4b6b72d, ada4c73): Synchronized [WorkspaceSettings.xcsettings](DragonglassApp/Dragonglass.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings) and updated Swift package dependencies.
- **Code Cleanup** (55b037a): Refined [BackendManager.swift](DragonglassApp/Dragonglass/BackendManager.swift) and [KeyRecorderView.swift](DragonglassApp/Dragonglass/KeyRecorderView.swift).

### Issues

Resolves #31 and #22 