### PR TITLE
fix: transcription not recording

### DIFF
--- a/DragonglassApp/Dragonglass.xcodeproj/project.pbxproj
+++ b/DragonglassApp/Dragonglass.xcodeproj/project.pbxproj
@@ -310,6 +310,7 @@
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Dragonglass uses the microphone for voice dictation.";
+				INFOPLIST_KEY_NSInputMonitoringUsageDescription = "Dragonglass monitors keyboard input to detect the push-to-talk hotkey.";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -349,6 +350,7 @@
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Dragonglass uses the microphone for voice dictation.";
+				INFOPLIST_KEY_NSInputMonitoringUsageDescription = "Dragonglass monitors keyboard input to detect the push-to-talk hotkey.";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",

--- a/DragonglassApp/Dragonglass/ContentView.swift
+++ b/DragonglassApp/Dragonglass/ContentView.swift
@@ -682,7 +682,7 @@ struct MicButton: View {
                 .onEnded { _ in sttManager.stopAndTranscribe() }
         )
         .onChange(of: isHolding) { _, holding in
-            if holding { sttManager.startRecording() }
+            if holding && !sttManager.isRecording { sttManager.startRecording() }
         }
         .disabled(!sttManager.micPermissionGranted || !sttManager.isModelReady || client.isThinking)
         .opacity(sttManager.micPermissionGranted && sttManager.isModelReady ? 1.0 : 0.3)

--- a/DragonglassApp/Dragonglass/ContentView.swift
+++ b/DragonglassApp/Dragonglass/ContentView.swift
@@ -652,7 +652,7 @@ struct ApprovalView: View {
 struct MicButton: View {
     @EnvironmentObject var sttManager: STTManager
     @EnvironmentObject var client: AgentClient
-    @State private var isHolding = false
+    @GestureState private var isHolding = false
     @State private var pulsing = false
 
     var body: some View {
@@ -678,17 +678,12 @@ struct MicButton: View {
         }
         .gesture(
             DragGesture(minimumDistance: 0)
-                .onChanged { _ in
-                    guard !isHolding else { return }
-                    isHolding = true
-                    sttManager.startRecording()
-                }
-                .onEnded { _ in
-                    guard isHolding else { return }
-                    isHolding = false
-                    sttManager.stopAndTranscribe()
-                }
+                .updating($isHolding) { _, state, _ in state = true }
+                .onEnded { _ in sttManager.stopAndTranscribe() }
         )
+        .onChange(of: isHolding) { _, holding in
+            if holding { sttManager.startRecording() }
+        }
         .disabled(!sttManager.micPermissionGranted || !sttManager.isModelReady || client.isThinking)
         .opacity(sttManager.micPermissionGranted && sttManager.isModelReady ? 1.0 : 0.3)
         .help(

--- a/DragonglassApp/Dragonglass/ContentView.swift
+++ b/DragonglassApp/Dragonglass/ContentView.swift
@@ -652,7 +652,6 @@ struct ApprovalView: View {
 struct MicButton: View {
     @EnvironmentObject var sttManager: STTManager
     @EnvironmentObject var client: AgentClient
-    @GestureState private var isHolding = false
     @State private var pulsing = false
 
     var body: some View {
@@ -676,13 +675,12 @@ struct MicButton: View {
                     .frame(width: 30, height: 30)
             }
         }
-        .gesture(
-            DragGesture(minimumDistance: 0)
-                .updating($isHolding) { _, state, _ in state = true }
-                .onEnded { _ in sttManager.stopAndTranscribe() }
-        )
-        .onChange(of: isHolding) { _, holding in
-            if holding && !sttManager.isRecording { sttManager.startRecording() }
+        .onTapGesture {
+            if sttManager.isRecording {
+                sttManager.stopAndTranscribe()
+            } else {
+                sttManager.startRecording()
+            }
         }
         .disabled(!sttManager.micPermissionGranted || !sttManager.isModelReady || client.isThinking)
         .opacity(sttManager.micPermissionGranted && sttManager.isModelReady ? 1.0 : 0.3)

--- a/DragonglassApp/Dragonglass/HotkeyManager.swift
+++ b/DragonglassApp/Dragonglass/HotkeyManager.swift
@@ -5,27 +5,21 @@ import os
 
 private let logger = Logger(subsystem: "com.antolu.dragonglass", category: "HotkeyManager")
 
-private final class HotkeyState: @unchecked Sendable {
-    var keyCode: Int = 0
-    var carbonModifiers: Int = 0
-    var isPressed = false
-}
-
 @MainActor
 final class HotkeyManager: NSObject, ObservableObject {
     @Published var accessibilityGranted = false
 
     private weak var sttManager: STTManager?
     private weak var menuBarManager: MenuBarManager?
+    private weak var agentClient: AgentClient?
 
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
 
-    nonisolated private let state = HotkeyState()
-
-    func setup(sttManager: STTManager, menuBarManager: MenuBarManager) {
+    func setup(sttManager: STTManager, menuBarManager: MenuBarManager, agentClient: AgentClient) {
         self.sttManager = sttManager
         self.menuBarManager = menuBarManager
+        self.agentClient = agentClient
         refreshAccessibility()
         registerIfPossible()
     }
@@ -41,12 +35,10 @@ final class HotkeyManager: NSObject, ObservableObject {
         let keyCode = UserDefaults.standard.integer(forKey: "sttHotkeyKeyCode")
         let modifiers = UserDefaults.standard.integer(forKey: "sttHotkeyModifiers")
         guard keyCode != 0 else { return }
-        state.keyCode = keyCode
-        state.carbonModifiers = modifiers
-        installEventTap()
+        installEventTap(keyCode: keyCode, carbonModifiers: modifiers)
     }
 
-    private func installEventTap() {
+    private func installEventTap(keyCode: Int, carbonModifiers: Int) {
         let mask: CGEventMask =
             (1 << CGEventType.keyDown.rawValue) |
             (1 << CGEventType.keyUp.rawValue) |
@@ -54,9 +46,12 @@ final class HotkeyManager: NSObject, ObservableObject {
 
         let callback: CGEventTapCallBack = { _, type, event, userInfo -> Unmanaged<CGEvent>? in
             guard let userInfo else { return Unmanaged.passUnretained(event) }
-            let manager = Unmanaged<HotkeyManager>.fromOpaque(userInfo).takeUnretainedValue()
-            return manager.handleEvent(type: type, event: event)
+            let ctx = Unmanaged<TapContext>.fromOpaque(userInfo).takeUnretainedValue()
+            return ctx.handle(type: type, event: event)
         }
+
+        let ctx = TapContext(state: TapContext.TapState(keyCode: keyCode, carbonModifiers: carbonModifiers), manager: self)
+        let ctxPtr = Unmanaged.passRetained(ctx)
 
         guard let tap = CGEvent.tapCreate(
             tap: .cgSessionEventTap,
@@ -64,8 +59,9 @@ final class HotkeyManager: NSObject, ObservableObject {
             options: .defaultTap,
             eventsOfInterest: mask,
             callback: callback,
-            userInfo: Unmanaged.passUnretained(self).toOpaque()
+            userInfo: ctxPtr.toOpaque()
         ) else {
+            ctxPtr.release()
             print("[HotkeyManager] CGEvent.tapCreate failed — check Input Monitoring permission")
             return
         }
@@ -77,47 +73,6 @@ final class HotkeyManager: NSObject, ObservableObject {
         CGEvent.tapEnable(tap: tap, enable: true)
     }
 
-    nonisolated private func handleEvent(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
-        let keyCode = Int(event.getIntegerValueField(.keyboardEventKeycode))
-        let cgFlags = event.flags
-
-        let nsFlags = NSEvent.ModifierFlags(rawValue: UInt(cgFlags.rawValue))
-        let eventCarbon = HotkeyManager.toCarbonModifiers(nsFlags)
-
-        switch type {
-        case .keyDown:
-            guard keyCode == state.keyCode, eventCarbon == state.carbonModifiers, !state.isPressed else {
-                return Unmanaged.passUnretained(event)
-            }
-            logger.debug("keyDown matched at \(CACurrentMediaTime())")
-            state.isPressed = true
-            Task { @MainActor in self.onKeyDown() }
-            return nil
-
-        case .keyUp:
-            guard keyCode == state.keyCode, state.isPressed else {
-                return Unmanaged.passUnretained(event)
-            }
-            logger.debug("keyUp matched at \(CACurrentMediaTime())")
-            state.isPressed = false
-            Task { @MainActor in self.onKeyUp() }
-            return nil
-
-        case .flagsChanged:
-            guard state.isPressed else { return Unmanaged.passUnretained(event) }
-            let requiredNSFlags = HotkeyManager.toNSModifiers(carbonModifiers: state.carbonModifiers)
-            logger.debug("flagsChanged while pressed, flags=\(nsFlags.rawValue) required=\(requiredNSFlags.rawValue) at \(CACurrentMediaTime())")
-            if !nsFlags.contains(requiredNSFlags) {
-                state.isPressed = false
-                Task { @MainActor in self.onKeyUp() }
-            }
-            return Unmanaged.passUnretained(event)
-
-        default:
-            return Unmanaged.passUnretained(event)
-        }
-    }
-
     private func unregister() {
         if let tap = eventTap {
             CGEvent.tapEnable(tap: tap, enable: false)
@@ -127,16 +82,16 @@ final class HotkeyManager: NSObject, ObservableObject {
             eventTap = nil
             runLoopSource = nil
         }
-        state.isPressed = false
     }
 
     func onKeyDown() {
+        agentClient?.startNewChat()
+        menuBarManager?.showPopover()
         sttManager?.startRecording()
     }
 
     func onKeyUp() {
         sttManager?.stopAndTranscribe()
-        menuBarManager?.showPopover()
     }
 
     nonisolated static func toCarbonModifiers(_ flags: NSEvent.ModifierFlags) -> Int {
@@ -155,5 +110,66 @@ final class HotkeyManager: NSObject, ObservableObject {
         if carbonModifiers & optionKey != 0 { flags.insert(.option) }
         if carbonModifiers & controlKey != 0 { flags.insert(.control) }
         return flags
+    }
+}
+
+private final class TapContext: @unchecked Sendable {
+    final class TapState: @unchecked Sendable {
+        var isPressed = false
+        let keyCode: Int
+        let carbonModifiers: Int
+        init(keyCode: Int, carbonModifiers: Int) {
+            self.keyCode = keyCode
+            self.carbonModifiers = carbonModifiers
+        }
+    }
+
+    let state: TapState
+    weak var manager: HotkeyManager?
+
+    init(state: TapState, manager: HotkeyManager) {
+        self.state = state
+        self.manager = manager
+    }
+
+    func handle(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+        let keyCode = Int(event.getIntegerValueField(.keyboardEventKeycode))
+        let cgFlags = event.flags
+        let nsFlags = NSEvent.ModifierFlags(rawValue: UInt(cgFlags.rawValue))
+        let eventCarbon = HotkeyManager.toCarbonModifiers(nsFlags)
+
+        switch type {
+        case .keyDown:
+            guard keyCode == state.keyCode, eventCarbon == state.carbonModifiers else {
+                return Unmanaged.passUnretained(event)
+            }
+            let isRepeat = event.getIntegerValueField(.keyboardEventAutorepeat) != 0
+            if isRepeat || state.isPressed { return nil }
+            logger.debug("keyDown matched at \(CACurrentMediaTime())")
+            state.isPressed = true
+            Task { @MainActor [weak manager] in manager?.onKeyDown() }
+            return nil
+
+        case .keyUp:
+            guard keyCode == state.keyCode, state.isPressed else {
+                return Unmanaged.passUnretained(event)
+            }
+            logger.debug("keyUp matched at \(CACurrentMediaTime())")
+            state.isPressed = false
+            Task { @MainActor [weak manager] in manager?.onKeyUp() }
+            return nil
+
+        case .flagsChanged:
+            guard state.isPressed else { return Unmanaged.passUnretained(event) }
+            let requiredNSFlags = HotkeyManager.toNSModifiers(carbonModifiers: state.carbonModifiers)
+            if !nsFlags.contains(requiredNSFlags) {
+                state.isPressed = false
+                Task { @MainActor [weak manager] in manager?.onKeyUp() }
+            }
+            return Unmanaged.passUnretained(event)
+
+        default:
+            return Unmanaged.passUnretained(event)
+        }
     }
 }

--- a/DragonglassApp/Dragonglass/HotkeyManager.swift
+++ b/DragonglassApp/Dragonglass/HotkeyManager.swift
@@ -85,13 +85,13 @@ final class HotkeyManager: NSObject, ObservableObject {
     }
 
     func onKeyDown() {
-        agentClient?.startNewChat()
-        menuBarManager?.showPopover()
-        sttManager?.startRecording()
-    }
-
-    func onKeyUp() {
-        sttManager?.stopAndTranscribe()
+        if sttManager?.isRecording == true {
+            sttManager?.stopAndTranscribe()
+        } else {
+            agentClient?.startNewChat()
+            menuBarManager?.showPopover()
+            sttManager?.startRecording()
+        }
     }
 
     nonisolated static func toCarbonModifiers(_ flags: NSEvent.ModifierFlags) -> Int {
@@ -154,9 +154,7 @@ private final class TapContext: @unchecked Sendable {
             guard keyCode == state.keyCode, state.isPressed else {
                 return Unmanaged.passUnretained(event)
             }
-            logger.debug("keyUp matched at \(CACurrentMediaTime())")
             state.isPressed = false
-            Task { @MainActor [weak manager] in manager?.onKeyUp() }
             return nil
 
         case .flagsChanged:
@@ -164,7 +162,6 @@ private final class TapContext: @unchecked Sendable {
             let requiredNSFlags = HotkeyManager.toNSModifiers(carbonModifiers: state.carbonModifiers)
             if !nsFlags.contains(requiredNSFlags) {
                 state.isPressed = false
-                Task { @MainActor [weak manager] in manager?.onKeyUp() }
             }
             return Unmanaged.passUnretained(event)
 

--- a/DragonglassApp/Dragonglass/HotkeyManager.swift
+++ b/DragonglassApp/Dragonglass/HotkeyManager.swift
@@ -2,6 +2,12 @@ import AppKit
 import Carbon
 import Combine
 
+private final class HotkeyState: @unchecked Sendable {
+    var keyCode: Int = 0
+    var carbonModifiers: Int = 0
+    var isPressed = false
+}
+
 @MainActor
 final class HotkeyManager: NSObject, ObservableObject {
     @Published var accessibilityGranted = false
@@ -9,10 +15,10 @@ final class HotkeyManager: NSObject, ObservableObject {
     private weak var sttManager: STTManager?
     private weak var menuBarManager: MenuBarManager?
 
-    private var hotKeyRef: EventHotKeyRef?
-    private var eventHandlerRef: EventHandlerRef?
-    private var keyUpMonitor: Any?
-    private var currentKeyCode: Int = 0
+    private var eventTap: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
+
+    nonisolated private let state = HotkeyState()
 
     func setup(sttManager: STTManager, menuBarManager: MenuBarManager) {
         self.sttManager = sttManager
@@ -32,64 +38,116 @@ final class HotkeyManager: NSObject, ObservableObject {
         let keyCode = UserDefaults.standard.integer(forKey: "sttHotkeyKeyCode")
         let modifiers = UserDefaults.standard.integer(forKey: "sttHotkeyModifiers")
         guard keyCode != 0 else { return }
-        currentKeyCode = keyCode
-        register(keyCode: UInt32(keyCode), carbonModifiers: UInt32(modifiers))
+        state.keyCode = keyCode
+        state.carbonModifiers = modifiers
+        installEventTap()
     }
 
-    private func register(keyCode: UInt32, carbonModifiers: UInt32) {
-        let hotKeyID = EventHotKeyID(signature: 0x4452474C, id: 1)
-        var ref: EventHotKeyRef?
-        RegisterEventHotKey(keyCode, carbonModifiers, hotKeyID, GetEventDispatcherTarget(), 0, &ref)
-        hotKeyRef = ref
+    private func installEventTap() {
+        let mask: CGEventMask =
+            (1 << CGEventType.keyDown.rawValue) |
+            (1 << CGEventType.keyUp.rawValue) |
+            (1 << CGEventType.flagsChanged.rawValue)
 
-        var eventType = EventTypeSpec(
-            eventClass: OSType(kEventClassKeyboard),
-            eventKind: UInt32(kEventHotKeyPressed)
-        )
-        let callback: EventHandlerUPP = { _, _, userData -> OSStatus in
-            guard let userData else { return OSStatus(eventNotHandledErr) }
-            let manager = Unmanaged<HotkeyManager>.fromOpaque(userData).takeUnretainedValue()
-            Task { @MainActor in manager.onKeyDown() }
-            return noErr
-        }
-        let status = InstallEventHandler(
-            GetEventDispatcherTarget(),
-            callback,
-            1, &eventType,
-            Unmanaged.passUnretained(self).toOpaque(),
-            &eventHandlerRef
-        )
-        if status != noErr {
-            print("[HotkeyManager] InstallEventHandler failed: \(status)")
+        let callback: CGEventTapCallBack = { _, type, event, userInfo -> Unmanaged<CGEvent>? in
+            guard let userInfo else { return Unmanaged.passUnretained(event) }
+            let manager = Unmanaged<HotkeyManager>.fromOpaque(userInfo).takeUnretainedValue()
+            return manager.handleEvent(type: type, event: event)
         }
 
-        keyUpMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyUp) { [weak self] event in
-            guard let self, Int(event.keyCode) == self.currentKeyCode else { return }
+        guard let tap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: mask,
+            callback: callback,
+            userInfo: Unmanaged.passUnretained(self).toOpaque()
+        ) else {
+            print("[HotkeyManager] CGEvent.tapCreate failed — check Input Monitoring permission")
+            return
+        }
+
+        eventTap = tap
+        let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        runLoopSource = source
+        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+        CGEvent.tapEnable(tap: tap, enable: true)
+    }
+
+    nonisolated private func handleEvent(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+        let keyCode = Int(event.getIntegerValueField(.keyboardEventKeycode))
+        let cgFlags = event.flags
+
+        let nsFlags = NSEvent.ModifierFlags(rawValue: UInt(cgFlags.rawValue))
+        let eventCarbon = HotkeyManager.toCarbonModifiers(nsFlags)
+
+        switch type {
+        case .keyDown:
+            guard keyCode == state.keyCode, eventCarbon == state.carbonModifiers, !state.isPressed else {
+                return Unmanaged.passUnretained(event)
+            }
+            state.isPressed = true
+            Task { @MainActor in self.onKeyDown() }
+            return nil
+
+        case .keyUp:
+            guard keyCode == state.keyCode, state.isPressed else {
+                return Unmanaged.passUnretained(event)
+            }
+            state.isPressed = false
             Task { @MainActor in self.onKeyUp() }
+            return nil
+
+        case .flagsChanged:
+            guard state.isPressed else { return Unmanaged.passUnretained(event) }
+            let requiredNSFlags = HotkeyManager.toNSModifiers(carbonModifiers: state.carbonModifiers)
+            if !nsFlags.contains(requiredNSFlags) {
+                state.isPressed = false
+                Task { @MainActor in self.onKeyUp() }
+            }
+            return Unmanaged.passUnretained(event)
+
+        default:
+            return Unmanaged.passUnretained(event)
         }
     }
 
     private func unregister() {
-        if let ref = hotKeyRef { UnregisterEventHotKey(ref); hotKeyRef = nil }
-        if let ref = eventHandlerRef { RemoveEventHandler(ref); eventHandlerRef = nil }
-        if let mon = keyUpMonitor { NSEvent.removeMonitor(mon); keyUpMonitor = nil }
+        if let tap = eventTap {
+            CGEvent.tapEnable(tap: tap, enable: false)
+            if let source = runLoopSource {
+                CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+            }
+            eventTap = nil
+            runLoopSource = nil
+        }
+        state.isPressed = false
     }
 
     func onKeyDown() {
         sttManager?.startRecording()
-        menuBarManager?.showPopover()
     }
 
     func onKeyUp() {
         sttManager?.stopAndTranscribe()
+        menuBarManager?.showPopover()
     }
 
-    static func toCarbonModifiers(_ flags: NSEvent.ModifierFlags) -> Int {
+    nonisolated static func toCarbonModifiers(_ flags: NSEvent.ModifierFlags) -> Int {
         var carbon = 0
         if flags.contains(.command) { carbon |= cmdKey }
         if flags.contains(.shift) { carbon |= shiftKey }
         if flags.contains(.option) { carbon |= optionKey }
         if flags.contains(.control) { carbon |= controlKey }
         return carbon
+    }
+
+    nonisolated static func toNSModifiers(carbonModifiers: Int) -> NSEvent.ModifierFlags {
+        var flags: NSEvent.ModifierFlags = []
+        if carbonModifiers & cmdKey != 0 { flags.insert(.command) }
+        if carbonModifiers & shiftKey != 0 { flags.insert(.shift) }
+        if carbonModifiers & optionKey != 0 { flags.insert(.option) }
+        if carbonModifiers & controlKey != 0 { flags.insert(.control) }
+        return flags
     }
 }

--- a/DragonglassApp/Dragonglass/HotkeyManager.swift
+++ b/DragonglassApp/Dragonglass/HotkeyManager.swift
@@ -1,6 +1,9 @@
 import AppKit
 import Carbon
 import Combine
+import os
+
+private let logger = Logger(subsystem: "com.antolu.dragonglass", category: "HotkeyManager")
 
 private final class HotkeyState: @unchecked Sendable {
     var keyCode: Int = 0
@@ -86,6 +89,7 @@ final class HotkeyManager: NSObject, ObservableObject {
             guard keyCode == state.keyCode, eventCarbon == state.carbonModifiers, !state.isPressed else {
                 return Unmanaged.passUnretained(event)
             }
+            logger.debug("keyDown matched at \(CACurrentMediaTime())")
             state.isPressed = true
             Task { @MainActor in self.onKeyDown() }
             return nil
@@ -94,6 +98,7 @@ final class HotkeyManager: NSObject, ObservableObject {
             guard keyCode == state.keyCode, state.isPressed else {
                 return Unmanaged.passUnretained(event)
             }
+            logger.debug("keyUp matched at \(CACurrentMediaTime())")
             state.isPressed = false
             Task { @MainActor in self.onKeyUp() }
             return nil
@@ -101,6 +106,7 @@ final class HotkeyManager: NSObject, ObservableObject {
         case .flagsChanged:
             guard state.isPressed else { return Unmanaged.passUnretained(event) }
             let requiredNSFlags = HotkeyManager.toNSModifiers(carbonModifiers: state.carbonModifiers)
+            logger.debug("flagsChanged while pressed, flags=\(nsFlags.rawValue) required=\(requiredNSFlags.rawValue) at \(CACurrentMediaTime())")
             if !nsFlags.contains(requiredNSFlags) {
                 state.isPressed = false
                 Task { @MainActor in self.onKeyUp() }

--- a/DragonglassApp/Dragonglass/MenuBarManager.swift
+++ b/DragonglassApp/Dragonglass/MenuBarManager.swift
@@ -24,7 +24,7 @@ class MenuBarManager: NSObject, ObservableObject {
         self.sttManager = sttManager
         self.hotkeyManager = hotkeyManager
 
-        hotkeyManager.setup(sttManager: sttManager, menuBarManager: self)
+        hotkeyManager.setup(sttManager: sttManager, menuBarManager: self, agentClient: client)
 
         backend.$phase
             .receive(on: RunLoop.main)

--- a/DragonglassApp/Dragonglass/STTManager.swift
+++ b/DragonglassApp/Dragonglass/STTManager.swift
@@ -233,9 +233,8 @@ final class STTManager: ObservableObject {
             let confirmed = newState.confirmedSegments.map { $0.text }.joined()
             let current = newState.currentText
             let full = (confirmed + " " + current).trimmingCharacters(in: .whitespacesAndNewlines)
-            Task { @MainActor in
-                if !full.isEmpty { self.pendingText = full }
-            }
+            guard !full.isEmpty, full != "Waiting for speech..." else { return }
+            Task { @MainActor in self.pendingText = full }
         }
 
         streamTranscriber = transcriber
@@ -244,6 +243,8 @@ final class STTManager: ObservableObject {
         streamTask = Task {
             do {
                 try await transcriber.startStreamTranscription()
+            } catch is CancellationError {
+                // expected on stop
             } catch {
                 logger.error("Streaming transcription error: \(error.localizedDescription)")
             }
@@ -258,7 +259,6 @@ final class STTManager: ObservableObject {
         logger.info("Stopping recording")
         let transcriber = streamTranscriber
         streamTranscriber = nil
-        streamTask?.cancel()
         streamTask = nil
         isRecording = false
 

--- a/DragonglassApp/Dragonglass/STTManager.swift
+++ b/DragonglassApp/Dragonglass/STTManager.swift
@@ -34,7 +34,7 @@ final class STTManager: ObservableObject {
 
     private var whisperKit: WhisperKit?
     private var loadTask: Task<WhisperKit, Error>?
-    private var audioEngine: AVAudioEngine!
+    private let audioEngine = AVAudioEngine()
     private var audioSamples: [Float] = []
     private var converter: AVAudioConverter?
     private var autoSendTask: Task<Void, Never>?
@@ -221,7 +221,6 @@ final class STTManager: ObservableObject {
         audioSamples = []
 
         do {
-            audioEngine = AVAudioEngine()
             let inputNode = audioEngine.inputNode
             let hwFormat = inputNode.inputFormat(forBus: 0)
             logger.debug("Input format: \(hwFormat)")
@@ -243,26 +242,17 @@ final class STTManager: ObservableObject {
                 let outFrames = AVAudioFrameCount(Double(buffer.frameLength) * ratio + 1)
                 guard let converted = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: outFrames),
                       let channelData = converted.floatChannelData else { return }
-                var done = false
-                var error: NSError?
-                converter.convert(to: converted, error: &error) { _, outStatus in
-                    if done {
-                        outStatus.pointee = .endOfStream
-                        return nil
-                    }
-                    done = true
+                var nsError: NSError?
+                converter.convert(to: converted, error: &nsError) { _, outStatus in
                     outStatus.pointee = .haveData
                     return buffer
                 }
-                guard error == nil, converted.frameLength > 0 else { return }
+                guard nsError == nil, converted.frameLength > 0 else { return }
                 let count = Int(converted.frameLength)
                 let samples = Array(UnsafeBufferPointer(start: channelData[0], count: count))
                 self.audioQueue.async {
                     self.audioBuffer.samples.append(contentsOf: samples)
                     self.audioBuffer.tapCount += 1
-                    if self.audioBuffer.tapCount % 50 == 0 {
-                        logger.debug("Accumulated \(self.audioBuffer.samples.count) samples (tap #\(self.audioBuffer.tapCount))")
-                    }
                 }
             }
 
@@ -278,7 +268,7 @@ final class STTManager: ObservableObject {
 
     func stopAndTranscribe() {
         guard isRecording else { return }
-        logger.info("Stopping recording and starting transcription")
+        logger.info("Stopping recording and starting transcription at \(CACurrentMediaTime())")
         audioEngine.inputNode.removeTap(onBus: 0)
         audioEngine.stop()
         isRecording = false

--- a/DragonglassApp/Dragonglass/STTManager.swift
+++ b/DragonglassApp/Dragonglass/STTManager.swift
@@ -34,17 +34,9 @@ final class STTManager: ObservableObject {
 
     private var whisperKit: WhisperKit?
     private var loadTask: Task<WhisperKit, Error>?
-    private let audioEngine = AVAudioEngine()
-    private var audioSamples: [Float] = []
-    private var converter: AVAudioConverter?
+    private var streamTranscriber: AudioStreamTranscriber?
+    private var streamTask: Task<Void, Never>?
     private var autoSendTask: Task<Void, Never>?
-    private let audioQueue = DispatchQueue(label: "com.antolu.dragonglass.audio", qos: .userInteractive)
-
-    private final class AudioBuffer: @unchecked Sendable {
-        var samples: [Float] = []
-        var tapCount: Int = 0
-    }
-    private let audioBuffer = AudioBuffer()
 
     init() {
         logger.debug("Initializing STTManager")
@@ -87,7 +79,6 @@ final class STTManager: ObservableObject {
     func refreshLocalModels() {
         try? FileManager.default.createDirectory(atPath: modelRepoPath, withIntermediateDirectories: true)
         let contents = (try? FileManager.default.contentsOfDirectory(atPath: modelRepoPath)) ?? []
-        // Only include non-hidden directories (ignore .cache, etc.)
         let models = contents.filter { !$0.hasPrefix(".") }
         localModels = models
         logger.debug("Refreshed local models: \(models)")
@@ -213,106 +204,71 @@ final class STTManager: ObservableObject {
             logger.warning("startRecording failed: isRecording=\(self.isRecording), micGranted=\(self.micPermissionGranted), isModelReady=\(self.isModelReady)")
             return
         }
+        guard let wk = whisperKit, let tokenizer = wk.tokenizer else {
+            logger.warning("startRecording failed: whisperKit not ready")
+            return
+        }
+
         logger.info("Starting recording...")
         autoSendTask?.cancel()
         autoSendTask = nil
         pendingText = nil
         readyToFire = false
-        audioSamples = []
 
-        do {
-            let inputNode = audioEngine.inputNode
-            let hwFormat = inputNode.inputFormat(forBus: 0)
-            logger.debug("Input format: \(hwFormat)")
-            guard hwFormat.sampleRate > 0, hwFormat.channelCount > 0 else {
-                logger.error("Invalid hardware format: rate=\(hwFormat.sampleRate), channels=\(hwFormat.channelCount)")
-                return
+        let transcriber = AudioStreamTranscriber(
+            audioEncoder: wk.audioEncoder,
+            featureExtractor: wk.featureExtractor,
+            segmentSeeker: wk.segmentSeeker,
+            textDecoder: wk.textDecoder,
+            tokenizer: tokenizer,
+            audioProcessor: wk.audioProcessor,
+            decodingOptions: DecodingOptions(
+                temperature: 0.0,
+                skipSpecialTokens: true
+            ),
+            requiredSegmentsForConfirmation: 2,
+            useVAD: true
+        ) { [weak self] _, newState in
+            guard let self else { return }
+            let confirmed = newState.confirmedSegments.map { $0.text }.joined()
+            let current = newState.currentText
+            let full = (confirmed + " " + current).trimmingCharacters(in: .whitespacesAndNewlines)
+            Task { @MainActor in
+                if !full.isEmpty { self.pendingText = full }
             }
-            let targetFormat = AVAudioFormat(
-                commonFormat: .pcmFormatFloat32,
-                sampleRate: 16000,
-                channels: 1,
-                interleaved: false
-            )!
-            converter = AVAudioConverter(from: hwFormat, to: targetFormat)
-
-            inputNode.installTap(onBus: 0, bufferSize: 4096, format: hwFormat) { [weak self] buffer, _ in
-                guard let self, let converter = self.converter else { return }
-                let ratio = 16000.0 / hwFormat.sampleRate
-                let outFrames = AVAudioFrameCount(Double(buffer.frameLength) * ratio + 1)
-                guard let converted = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: outFrames),
-                      let channelData = converted.floatChannelData else { return }
-                var nsError: NSError?
-                converter.convert(to: converted, error: &nsError) { _, outStatus in
-                    outStatus.pointee = .haveData
-                    return buffer
-                }
-                guard nsError == nil, converted.frameLength > 0 else { return }
-                let count = Int(converted.frameLength)
-                let samples = Array(UnsafeBufferPointer(start: channelData[0], count: count))
-                self.audioQueue.async {
-                    self.audioBuffer.samples.append(contentsOf: samples)
-                    self.audioBuffer.tapCount += 1
-                }
-            }
-
-            try audioEngine.start()
-            isRecording = true
-            audioQueue.async { self.audioBuffer.tapCount = 0 }
-            logger.info("Recording started successfully")
-        } catch {
-            logger.error("audioEngine.start error: \(error.localizedDescription)")
-            print("[STTManager] startRecording error: \(error)")
         }
+
+        streamTranscriber = transcriber
+        isRecording = true
+
+        streamTask = Task {
+            do {
+                try await transcriber.startStreamTranscription()
+            } catch {
+                logger.error("Streaming transcription error: \(error.localizedDescription)")
+            }
+            await MainActor.run { self.isRecording = false }
+        }
+
+        logger.info("Recording started successfully")
     }
 
     func stopAndTranscribe() {
         guard isRecording else { return }
-        logger.info("Stopping recording and starting transcription at \(CACurrentMediaTime())")
-        audioEngine.inputNode.removeTap(onBus: 0)
-        audioEngine.stop()
+        logger.info("Stopping recording")
+        let transcriber = streamTranscriber
+        streamTranscriber = nil
+        streamTask?.cancel()
+        streamTask = nil
         isRecording = false
 
-        audioQueue.sync {
-            let samples = audioBuffer.samples
-            audioBuffer.samples = []
-            let currentTapCount = audioBuffer.tapCount
-            audioBuffer.tapCount = 0
-            logger.debug("Captured \(samples.count) samples (tap count: \(currentTapCount))")
-
-            Task { @MainActor in
-                await self.performTranscription(with: samples)
+        Task {
+            await transcriber?.stopStreamTranscription()
+            await MainActor.run {
+                guard let text = self.pendingText, !text.isEmpty else { return }
+                logger.info("Final transcription: \"\(text)\"")
+                if self.autoSend { self.scheduleAutoSend() }
             }
-        }
-    }
-
-    private func performTranscription(with samples: [Float]) async {
-        guard !samples.isEmpty else {
-            logger.warning("No samples captured, skipping transcription")
-            return
-        }
-
-        isTranscribing = true
-        do {
-            try await ensureLoaded()
-            guard let wk = whisperKit else { throw STTError.notLoaded }
-            logger.debug("Calling WhisperKit.transcribe")
-            let results = try await wk.transcribe(audioArray: samples)
-            let text = results
-                .map { $0.text }
-                .joined(separator: " ")
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            logger.info("Transcription result: \"\(text)\"")
-
-            self.isTranscribing = false
-            guard !text.isEmpty else { return }
-            self.pendingText = text
-            if self.autoSend {
-                self.scheduleAutoSend()
-            }
-        } catch {
-            logger.error("Transcription failed: \(error.localizedDescription)")
-            self.isTranscribing = false
         }
     }
 

--- a/DragonglassApp/Dragonglass/STTManager.swift
+++ b/DragonglassApp/Dragonglass/STTManager.swift
@@ -307,9 +307,9 @@ final class STTManager: ObservableObject {
             try await ensureLoaded()
             guard let wk = whisperKit else { throw STTError.notLoaded }
             logger.debug("Calling WhisperKit.transcribe")
-            let results = await wk.transcribe(audioArrays: [samples])
+            let results = try await wk.transcribe(audioArray: samples)
             let text = results
-                .compactMap { $0?.first?.text }
+                .map { $0.text }
                 .joined(separator: " ")
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             logger.info("Transcription result: \"\(text)\"")


### PR DESCRIPTION
This PR addresses several issues regarding the WhisperKit integration, audio recording reliability, and project-level entitlements for microphone access in the Dragonglass macOS app.

## Summary of Changes

### Audio Recording and WhisperKit
- **Recording Pipeline Overhaul** (0cd1d75): Improved the thread-safety and reliability of the [STTManager.swift](DragonglassApp/Dragonglass/STTManager.swift) recording pipeline. 
- **Audio Converter Fixes** (5026252): Resolved issues in the audio converter block that caused recording failures.
- **Model Discovery Logic** (0f58bb9, 3e5a38d): Enhanced the model discovery mechanism in [STTManager.swift](DragonglassApp/Dragonglass/STTManager.swift) to correctly handle disk size calculations and filter out hidden directories (e.g., .cache) during path resolution.
- **Initialization Refinement** (ac2166b): Deferred AVAudioEngine initialization to ensure proper setup before usage.

### Permissions and Security
- **Microphone Entitlements** (37d8611): Added the mandatory `com.apple.security.device.audio-input` entitlement to [Dragonglass.entitlements](DragonglassApp/Dragonglass.entitlements).
- **Privacy Strings** (37d8611): Included `NSMicrophoneUsageDescription` in [Info.plist](DragonglassApp/Dragonglass/Info.plist) to properly request user permission for audio recording.

### Project Configuration and Maintenance
- **Improved Git Hygiene** (32b8dcc, 7a64071): Updated [.gitignore](.gitignore) to better exclude Xcode-generated files like DerivedData and xuserdata.
- **Workspace and Package Resolution** (4b6b72d, ada4c73): Synchronized [WorkspaceSettings.xcsettings](DragonglassApp/Dragonglass.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings) and updated Swift package dependencies.
- **Code Cleanup** (55b037a): Refined [BackendManager.swift](DragonglassApp/Dragonglass/BackendManager.swift) and [KeyRecorderView.swift](DragonglassApp/Dragonglass/KeyRecorderView.swift).
