### PR TITLE
fix: Settings UI alignment

### DIFF
--- a/DragonglassApp/Dragonglass/STTManager.swift
+++ b/DragonglassApp/Dragonglass/STTManager.swift
@@ -14,6 +14,7 @@ final class STTManager: ObservableObject {
     @Published var readyToFire = false
     @Published var downloadProgress: [String: Double] = [:]
     @Published var availableModels: [String] = []
+    @Published var modelSizes: [String: Int] = [:]
     @Published var localModels: [String] = []
     @Published var micPermissionGranted = false
     @Published var accessibilityGranted = false
@@ -100,6 +101,22 @@ final class STTManager: ObservableObject {
             models.insert(m, at: 0)
         }
         availableModels = models
+        modelSizes = Self.loadManifestSizes()
+    }
+
+    private static func loadManifestSizes() -> [String: Int] {
+        guard let url = Bundle.main.url(forResource: "whisper_models", withExtension: "json"),
+              let data = try? Data(contentsOf: url),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let models = json["models"] as? [[String: Any]]
+        else { return [:] }
+        var sizes: [String: Int] = [:]
+        for entry in models {
+            if let name = entry["name"] as? String, let bytes = entry["size_bytes"] as? Int {
+                sizes[name] = bytes
+            }
+        }
+        return sizes
     }
 
     func downloadModel(_ modelName: String) {

--- a/DragonglassApp/Dragonglass/SettingsView.swift
+++ b/DragonglassApp/Dragonglass/SettingsView.swift
@@ -194,17 +194,22 @@ struct SettingsView: View {
                 let opencodeAvailable = config.opencodeAvailable.wrappedValue ?? true
                 let opencodeDisabledReason = config.opencodeDisabledReason.wrappedValue
 
-                Picker("Backend", selection: config.llmBackend) {
-                    Text("LiteLLM").tag("litellm")
-                    Text("OpenCode")
-                        .tag("opencode")
-                        .disabled(!opencodeAvailable)
-                        .help(opencodeDisabledReason ?? "OpenCode is unavailable")
-                }
-                .pickerStyle(.segmented)
-                .onChange(of: config.llmBackend.wrappedValue) { _, newBackend in
-                    config.selectedModel.wrappedValue = ""
-                    client.setBackend(newBackend)
+                HStack {
+                    Text("Backend")
+                    Spacer()
+                    Picker("", selection: config.llmBackend) {
+                        Text("LiteLLM").tag("litellm")
+                        Text("OpenCode")
+                            .tag("opencode")
+                            .disabled(!opencodeAvailable)
+                            .help(opencodeDisabledReason ?? "OpenCode is unavailable")
+                    }
+                    .pickerStyle(.segmented)
+                    .fixedSize()
+                    .onChange(of: config.llmBackend.wrappedValue) { _, newBackend in
+                        config.selectedModel.wrappedValue = ""
+                        client.setBackend(newBackend)
+                    }
                 }
 
                 if !opencodeAvailable {

--- a/DragonglassApp/Dragonglass/SpeechSettingsView.swift
+++ b/DragonglassApp/Dragonglass/SpeechSettingsView.swift
@@ -196,6 +196,11 @@ struct ModelRowView: View {
                     .foregroundColor(.red)
                     .font(.caption2)
             } else {
+                if let bytes = sttManager.modelSizes[modelName] {
+                    Text(ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .file))
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
                 Button("Download") { sttManager.downloadModel(modelName) }
                     .buttonStyle(.plain)
                     .foregroundColor(.accentColor)

--- a/DragonglassApp/Dragonglass/SpeechSettingsView.swift
+++ b/DragonglassApp/Dragonglass/SpeechSettingsView.swift
@@ -31,10 +31,48 @@ struct SpeechSettingsView: View {
 
             Divider()
 
+            modelListSection
+        }
+        .onAppear {
+            sttManager.refreshLocalModels()
+            sttManager.checkAccessibilityPermission()
+            hotkeyManager.refreshAccessibility()
+            Task { await sttManager.fetchAvailableModels() }
+        }
+    }
+
+    @State private var modelsExpanded = false
+
+    private var unusedLocalModels: [String] {
+        sttManager.localModels.filter { $0 != sttManager.selectedModel }
+    }
+
+    private var modelListSection: some View {
+        DisclosureGroup(isExpanded: $modelsExpanded) {
+            VStack(spacing: 2) {
+                if sttManager.availableModels.isEmpty {
+                    ProgressView("Fetching model list…")
+                        .font(.caption)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.top, 4)
+                } else {
+                    ForEach(sttManager.availableModels, id: \.self) { model in
+                        ModelRowView(modelName: model)
+                            .environmentObject(sttManager)
+                    }
+                }
+            }
+            .padding(.top, 4)
+        } label: {
             HStack {
                 Text("Whisper model")
                     .font(.caption)
                     .foregroundColor(.secondary)
+                if !sttManager.selectedModel.isEmpty {
+                    Text(sttManager.selectedModel)
+                        .font(.caption)
+                        .foregroundColor(.primary)
+                }
                 Spacer()
                 if sttManager.isModelLoading {
                     ProgressView()
@@ -44,27 +82,19 @@ struct SpeechSettingsView: View {
                         .font(.caption2)
                         .foregroundColor(.secondary)
                 }
-            }
-
-            if sttManager.availableModels.isEmpty {
-                ProgressView("Fetching model list…")
-                    .font(.caption)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            } else {
-                VStack(spacing: 2) {
-                    ForEach(sttManager.availableModels, id: \.self) { model in
-                        ModelRowView(modelName: model)
-                            .environmentObject(sttManager)
+                if !unusedLocalModels.isEmpty && !modelsExpanded {
+                    Button("Clean Up (\(unusedLocalModels.count))") {
+                        for model in unusedLocalModels {
+                            sttManager.deleteModel(model)
+                        }
                     }
+                    .buttonStyle(.plain)
+                    .foregroundColor(.orange)
+                    .font(.caption2)
                 }
             }
         }
-        .onAppear {
-            sttManager.refreshLocalModels()
-            sttManager.checkAccessibilityPermission()
-            hotkeyManager.refreshAccessibility()
-            Task { await sttManager.fetchAvailableModels() }
-        }
+        .font(.caption)
     }
 
     private var micPermissionRow: some View {

--- a/DragonglassApp/Dragonglass/SpeechSettingsView.swift
+++ b/DragonglassApp/Dragonglass/SpeechSettingsView.swift
@@ -161,6 +161,7 @@ struct SpeechSettingsView: View {
 struct ModelRowView: View {
     let modelName: String
     @EnvironmentObject var sttManager: STTManager
+    @State private var confirmDownload = false
 
     private var isLocal: Bool { sttManager.localModels.contains(modelName) }
     private var isActive: Bool { sttManager.selectedModel == modelName }
@@ -204,7 +205,17 @@ struct ModelRowView: View {
         .padding(.vertical, 2)
         .contentShape(Rectangle())
         .onTapGesture {
-            if isLocal { sttManager.switchModel(to: modelName) }
+            if isLocal {
+                sttManager.switchModel(to: modelName)
+            } else if progress == nil {
+                confirmDownload = true
+            }
+        }
+        .confirmationDialog("Download \(modelName)?", isPresented: $confirmDownload) {
+            Button("Download") { sttManager.downloadModel(modelName) }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This model is not downloaded yet.")
         }
     }
 

--- a/DragonglassApp/Dragonglass/whisper_models.json
+++ b/DragonglassApp/Dragonglass/whisper_models.json
@@ -1,0 +1,135 @@
+{
+  "models": [
+    {
+      "name": "openai_whisper-tiny",
+      "size_bytes": 76689408,
+      "md5": "7147518a3d68ddbea0691e04cfffa4ff"
+    },
+    {
+      "name": "openai_whisper-tiny.en",
+      "size_bytes": 153067520,
+      "md5": "e1183fd55448923b1ce43a2da67aa21f"
+    },
+    {
+      "name": "openai_whisper-base",
+      "size_bytes": 146776064,
+      "md5": "36e60501ad0f01c1a5719e83a1f63f20"
+    },
+    {
+      "name": "openai_whisper-base.en",
+      "size_bytes": 146763776,
+      "md5": "fbcfd586f15e2952251b1d3257f18471"
+    },
+    {
+      "name": "openai_whisper-small",
+      "size_bytes": 486535168,
+      "md5": "f1d21adb950bc9be5d5343bcdeccd23b"
+    },
+    {
+      "name": "openai_whisper-small_216MB",
+      "size_bytes": 217399296
+    },
+    {
+      "name": "openai_whisper-small.en",
+      "size_bytes": 486559744,
+      "md5": "38efe6a00706bbdb995795c67a836e5e"
+    },
+    {
+      "name": "openai_whisper-small.en_217MB",
+      "size_bytes": 217931776
+    },
+    {
+      "name": "openai_whisper-medium",
+      "size_bytes": 1529700352
+    },
+    {
+      "name": "openai_whisper-medium.en",
+      "size_bytes": 1529724928
+    },
+    {
+      "name": "openai_whisper-large-v2",
+      "size_bytes": 3107049472,
+      "md5": "21b86c07318aeeef54598f15b7903979"
+    },
+    {
+      "name": "openai_whisper-large-v2_949MB",
+      "size_bytes": 952213504,
+      "md5": "71bad4e1566749d1060eda42308d9fb4"
+    },
+    {
+      "name": "openai_whisper-large-v2_turbo",
+      "size_bytes": 3096498176,
+      "md5": "7734959b6550e7b5c2d732bf2b7acd23"
+    },
+    {
+      "name": "openai_whisper-large-v2_turbo_955MB",
+      "size_bytes": 1053196288,
+      "md5": "cb6411862a48ec75325572081f01e5b5"
+    },
+    {
+      "name": "openai_whisper-large-v3",
+      "size_bytes": 3106975744,
+      "md5": "a6f24dc72785722e9cea89e227856dfe"
+    },
+    {
+      "name": "openai_whisper-large-v3_947MB",
+      "size_bytes": 948158464,
+      "md5": "ef6b0e9622a046ce2361b4c72307877f"
+    },
+    {
+      "name": "openai_whisper-large-v3_turbo",
+      "size_bytes": 3211784192,
+      "md5": "c550fbdea70c5784d322c0a427f8b5cd"
+    },
+    {
+      "name": "openai_whisper-large-v3_turbo_954MB",
+      "size_bytes": 1052909568,
+      "md5": "e639c4bb98d905064ef5dd38757dd9d1"
+    },
+    {
+      "name": "openai_whisper-large-v3-v20240930",
+      "size_bytes": 1619582976,
+      "md5": "17ebd78ff7edfa59001b554e9cc4c021"
+    },
+    {
+      "name": "openai_whisper-large-v3-v20240930_547MB",
+      "size_bytes": 549605376,
+      "md5": "c945dad68449ac3c78ecb2d561ac189d"
+    },
+    {
+      "name": "openai_whisper-large-v3-v20240930_626MB",
+      "size_bytes": 626769920,
+      "md5": "578fe5a07f4eb7e4187c920bca571aa5"
+    },
+    {
+      "name": "openai_whisper-large-v3-v20240930_turbo",
+      "size_bytes": 1638526976,
+      "md5": "dfbf09ab741af1d5400ddbd07bb37dad"
+    },
+    {
+      "name": "openai_whisper-large-v3-v20240930_turbo_632MB",
+      "size_bytes": 645730304,
+      "md5": "33954440dbd785ca1828afe25514f5a5"
+    },
+    {
+      "name": "distil-whisper_distil-large-v3",
+      "size_bytes": 1514586112,
+      "md5": "9cd8271143b919402ae776c30b479565"
+    },
+    {
+      "name": "distil-whisper_distil-large-v3_594MB",
+      "size_bytes": 594587648,
+      "md5": "ca532f45ddbf8a3d241132cc5cf41639"
+    },
+    {
+      "name": "distil-whisper_distil-large-v3_turbo",
+      "size_bytes": 1527177216,
+      "md5": "b8638452c6568dfe33a33bfcc2bc6aca"
+    },
+    {
+      "name": "distil-whisper_distil-large-v3_turbo_600MB",
+      "size_bytes": 607178752,
+      "md5": "81746b4b1afbbb01a8ae9ea452460d88"
+    }
+  ]
+}


### PR DESCRIPTION
This PR introduces improvements to the Speech-to-Text (STT) model management workflow and minor UI alignment fixes in the settings panel.

## Model Manifest and Size Visibility
- Added a bundled [DragonglassApp/Dragonglass/whisper_models.json](DragonglassApp/Dragonglass/whisper_models.json) manifest containing sizes for all supported Whisper models.
- Updated [DragonglassApp/Dragonglass/STTManager.swift](DragonglassApp/Dragonglass/STTManager.swift#0bf7f67d910a71f7671dbae91d3bec218f8761f8) to load this manifest, enabling the UI to display model sizes before downloading.

## Improved Model Management UI
- Refactored the [DragonglassApp/Dragonglass/SpeechSettingsView.swift](DragonglassApp/Dragonglass/SpeechSettingsView.swift#321e071b78a5ab5811713ca67f9b1477660700c7) to use a collapsible `DisclosureGroup` for the model list, making the settings panel more compact.
- Implemented a "Clean Up" feature to bulk-delete unused local models.
- Added individual "Delete" buttons for downloaded models.

## Interactive Download Workflow
- Users are now prompted with a confirmation dialog when tapping a model row to start a download, preventing accidental large downloads.
- Integrated download progress bars and percentage labels directly into the model list rows.

## UI Improvements
- Properly right-aligned the backend picker in [DragonglassApp/Dragonglass/SettingsView.swift](DragonglassApp/Dragonglass/SettingsView.swift#e156704384f36b424f715cbf547309a1b32db9b3) for better visual balance and consistency with other macOS settings patterns.

Resolves #20 , #21 , #24 , #25 