### PR TITLE
feat: Swift app chat window improvements

### DIFF
--- a/DragonglassApp/Dragonglass/ContentView.swift
+++ b/DragonglassApp/Dragonglass/ContentView.swift
@@ -49,7 +49,7 @@ struct ContentView: View {
             }
             .buttonStyle(.plain)
             .focusable(false)
-            .disabled(client.isThinking)
+            .disabled(client.isThinking || client.turns.isEmpty)
 
             Button(action: {
                 guard !client.isThinking else { return }

--- a/DragonglassApp/Dragonglass/ContentView.swift
+++ b/DragonglassApp/Dragonglass/ContentView.swift
@@ -1,6 +1,14 @@
 import SwiftUI
 
 struct ContentView: View {
+    private enum ResizeDragMode {
+        case bottom
+        case bottomLeading
+        case bottomTrailing
+    }
+
+    private let minWindowWidth: CGFloat = 400
+    private let minWindowHeight: CGFloat = 500
     @EnvironmentObject var backend: BackendManager
     @EnvironmentObject var client: AgentClient
     @EnvironmentObject var sttManager: STTManager
@@ -16,6 +24,7 @@ struct ContentView: View {
     @State private var escapeMonitor: Any?
     @State private var shiftMonitor: Any?
     @State private var includeToolCallsInSelection = false
+    @State private var resizeStartFrame: CGRect?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -29,7 +38,40 @@ struct ContentView: View {
 
             inputArea
         }
-        .frame(width: 400, height: 500)
+        .frame(minWidth: minWindowWidth, minHeight: minWindowHeight)
+        .overlay(alignment: .bottom) {
+            ZStack(alignment: .bottom) {
+                Color.clear
+                    .frame(height: 12)
+                    .contentShape(Rectangle())
+                    .gesture(
+                        DragGesture(minimumDistance: 0)
+                            .onChanged { value in handleResizeDragChanged(value, mode: .bottom) }
+                            .onEnded { value in handleResizeDragEnded(value, mode: .bottom) }
+                    )
+
+                HStack {
+                    Color.clear
+                        .frame(width: 16, height: 16)
+                        .contentShape(Rectangle())
+                        .gesture(
+                            DragGesture(minimumDistance: 0)
+                                .onChanged { value in handleResizeDragChanged(value, mode: .bottomLeading) }
+                                .onEnded { value in handleResizeDragEnded(value, mode: .bottomLeading) }
+                        )
+                    Spacer(minLength: 0)
+                    Color.clear
+                        .frame(width: 16, height: 16)
+                        .contentShape(Rectangle())
+                        .gesture(
+                            DragGesture(minimumDistance: 0)
+                                .onChanged { value in handleResizeDragChanged(value, mode: .bottomTrailing) }
+                                .onEnded { value in handleResizeDragEnded(value, mode: .bottomTrailing) }
+                        )
+                }
+                .frame(height: 16)
+            }
+        }
         .sheet(item: $client.pendingApproval) { req in
             ApprovalView(request: req)
                 .environmentObject(client)
@@ -430,6 +472,40 @@ struct ContentView: View {
 
         client.sendChat(text: inputText, model: model)
         inputText = ""
+    }
+
+    private func handleResizeDragChanged(_ value: DragGesture.Value, mode: ResizeDragMode) {
+        guard let window = NSApp.keyWindow else { return }
+        if resizeStartFrame == nil {
+            resizeStartFrame = window.frame
+        }
+        guard let startFrame = resizeStartFrame else { return }
+
+        let targetHeight = max(minWindowHeight, startFrame.height + value.translation.height)
+        let signedHorizontalTranslation: CGFloat
+        switch mode {
+        case .bottom:
+            signedHorizontalTranslation = 0
+        case .bottomLeading:
+            signedHorizontalTranslation = -value.translation.width
+        case .bottomTrailing:
+            signedHorizontalTranslation = value.translation.width
+        }
+        let targetWidth = max(minWindowWidth, startFrame.width + (signedHorizontalTranslation * 2))
+        let maxY = startFrame.maxY
+        let midX = startFrame.midX
+        let newFrame = CGRect(
+            x: midX - (targetWidth / 2),
+            y: maxY - targetHeight,
+            width: targetWidth,
+            height: targetHeight
+        )
+        window.setFrame(newFrame, display: true)
+    }
+
+    private func handleResizeDragEnded(_ value: DragGesture.Value, mode: ResizeDragMode) {
+        handleResizeDragChanged(value, mode: mode)
+        resizeStartFrame = nil
     }
 
     private func shouldPersistCustomModel(completedEventIndex: Int) -> Bool {

--- a/DragonglassApp/Dragonglass/ContentView.swift
+++ b/DragonglassApp/Dragonglass/ContentView.swift
@@ -14,6 +14,8 @@ struct ContentView: View {
     @State private var showingConversations = false
     @State private var isAtBottom = true
     @State private var escapeMonitor: Any?
+    @State private var shiftMonitor: Any?
+    @State private var includeToolCallsInSelection = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -239,21 +241,35 @@ struct ContentView: View {
                         .cornerRadius(6)
                     }
                     ForEach(client.prefixEventIndices, id: \.self) { index in
-                        EventRow(event: client.events[index], detailed: client.detailedToolEvents)
+                        EventRow(event: client.events[index], detailed: client.detailedToolEvents, includeToolCalls: includeToolCallsInSelection)
                     }
 
                     ForEach(client.turns) { turn in
-                        EventRow(event: client.events[turn.userMessageIndex], detailed: client.detailedToolEvents)
+                        EventRow(event: client.events[turn.userMessageIndex], detailed: client.detailedToolEvents, includeToolCalls: includeToolCallsInSelection)
 
                         if turn.isCompleted {
-                            CollapsedToolSummary(turn: turn, events: client.events, detailed: client.detailedToolEvents, onOpenNote: { client.openNote(path: $0) })
+                            CollapsedToolSummary(
+                                turn: turn,
+                                events: client.events,
+                                detailed: client.detailedToolEvents,
+                                includeToolCalls: includeToolCallsInSelection,
+                                onOpenNote: { client.openNote(path: $0) }
+                            )
                             if let doneIdx = turn.doneIndex {
-                                EventRow(event: client.events[doneIdx], detailed: client.detailedToolEvents)
+                                EventRow(event: client.events[doneIdx], detailed: client.detailedToolEvents, includeToolCalls: includeToolCallsInSelection)
                             }
                         } else {
                             if let idx = turn.toolCallIndices.last,
                                case .mcpTool(let t, let p, let m, let d) = client.events[idx] {
-                                ToolCallBadge(tool: t, phase: p, message: m, detail: d, detailed: client.detailedToolEvents, onOpenNote: { client.openNote(path: $0) })
+                                ToolCallBadge(
+                                    tool: t,
+                                    phase: p,
+                                    message: m,
+                                    detail: d,
+                                    detailed: client.detailedToolEvents,
+                                    selectable: includeToolCallsInSelection,
+                                    onOpenNote: { client.openNote(path: $0) }
+                                )
                                     .id(idx)
                                     .transition(.asymmetric(
                                         insertion: .move(edge: .bottom).combined(with: .opacity),
@@ -263,7 +279,7 @@ struct ContentView: View {
                         }
 
                         if let aIdx = turn.assistantMessageIndex {
-                            EventRow(event: client.events[aIdx], detailed: client.detailedToolEvents)
+                            EventRow(event: client.events[aIdx], detailed: client.detailedToolEvents, includeToolCalls: includeToolCallsInSelection)
                         }
                     }
 
@@ -272,6 +288,7 @@ struct ContentView: View {
                     }
                 }
                 .padding()
+                .textSelection(.enabled)
 
                 GeometryReader { geo in
                     Color.clear.preference(
@@ -384,6 +401,11 @@ struct ContentView: View {
             }
             return event
         }
+
+        shiftMonitor = NSEvent.addLocalMonitorForEvents(matching: [.flagsChanged, .leftMouseDown, .leftMouseDragged, .leftMouseUp]) { event in
+            self.includeToolCallsInSelection = event.modifierFlags.contains(.shift)
+            return event
+        }
     }
 
     private func removeEscapeMonitor() {
@@ -391,6 +413,11 @@ struct ContentView: View {
             NSEvent.removeMonitor(mon)
             escapeMonitor = nil
         }
+        if let mon = shiftMonitor {
+            NSEvent.removeMonitor(mon)
+            shiftMonitor = nil
+        }
+        includeToolCallsInSelection = false
     }
 
     private func sendMessage() {
@@ -438,6 +465,7 @@ struct ContentView: View {
 struct EventRow: View {
     let event: AgentEvent
     var detailed: Bool = false
+    var includeToolCalls: Bool = false
 
     var body: some View {
         switch event {
@@ -475,7 +503,7 @@ struct EventRow: View {
                     .cornerRadius(8)
             }
         case .approvalRequest(let req):
-            HStack(spacing: 6) {
+            let row = HStack(spacing: 6) {
                 Image(systemName: "pencil.circle")
                     .foregroundColor(.orange)
                 Text("Pending approval: \(req.description)")
@@ -485,6 +513,11 @@ struct EventRow: View {
             .padding(4)
             .background(Color.orange.opacity(0.08))
             .cornerRadius(4)
+            if includeToolCalls {
+                row.textSelection(.enabled)
+            } else {
+                row.textSelection(.disabled)
+            }
         case .unknown(let type):
             Text("Unknown event: \(type)")
                 .font(.caption)
@@ -515,6 +548,7 @@ struct ToolCallBadge: View {
     let detail: String
     var detailed: Bool = false
     var onOpenNote: ((String) -> Void)?
+    var selectable: Bool = false
     @State private var showingDetail = false
 
     private var toolPhase: ToolPhase { ToolPhase(rawValue: phase) }
@@ -547,7 +581,7 @@ struct ToolCallBadge: View {
     }
 
     var body: some View {
-        HStack(alignment: .top, spacing: 6) {
+        let badge = HStack(alignment: .top, spacing: 6) {
             if toolPhase == .error {
                 Image(systemName: "exclamationmark.circle")
                     .foregroundColor(.red)
@@ -585,6 +619,11 @@ struct ToolCallBadge: View {
             }
             .frame(maxHeight: 200)
         }
+        if selectable {
+            badge.textSelection(.enabled)
+        } else {
+            badge.textSelection(.disabled)
+        }
     }
 }
 
@@ -593,6 +632,7 @@ struct CollapsedToolSummary: View {
     let events: [AgentEvent]
     var detailed: Bool = false
     var onOpenNote: ((String) -> Void)?
+    var includeToolCalls: Bool = false
     @State private var isExpanded = false
 
     var body: some View {
@@ -602,7 +642,15 @@ struct CollapsedToolSummary: View {
                 VStack(alignment: .leading, spacing: 4) {
                     ForEach(turn.toolCallIndices, id: \.self) { idx in
                         if case .mcpTool(let t, let p, let m, let d) = events[idx] {
-                            ToolCallBadge(tool: t, phase: p, message: m, detail: d, detailed: detailed, onOpenNote: onOpenNote)
+                            ToolCallBadge(
+                                tool: t,
+                                phase: p,
+                                message: m,
+                                detail: d,
+                                detailed: detailed,
+                                selectable: includeToolCalls,
+                                onOpenNote: onOpenNote
+                            )
                         }
                     }
                 }
@@ -612,6 +660,7 @@ struct CollapsedToolSummary: View {
                 Text("\(count) tool call\(count == 1 ? "" : "s")")
                     .font(.caption)
                     .foregroundColor(.secondary)
+                    .textSelection(.disabled)
             }
         )
     }

--- a/DragonglassApp/Dragonglass/ContentView.swift
+++ b/DragonglassApp/Dragonglass/ContentView.swift
@@ -1,14 +1,6 @@
 import SwiftUI
 
 struct ContentView: View {
-    private enum ResizeDragMode {
-        case bottom
-        case bottomLeading
-        case bottomTrailing
-    }
-
-    private let minWindowWidth: CGFloat = 400
-    private let minWindowHeight: CGFloat = 500
     @EnvironmentObject var backend: BackendManager
     @EnvironmentObject var client: AgentClient
     @EnvironmentObject var sttManager: STTManager
@@ -24,7 +16,6 @@ struct ContentView: View {
     @State private var escapeMonitor: Any?
     @State private var shiftMonitor: Any?
     @State private var includeToolCallsInSelection = false
-    @State private var resizeStartFrame: CGRect?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -38,40 +29,7 @@ struct ContentView: View {
 
             inputArea
         }
-        .frame(minWidth: minWindowWidth, minHeight: minWindowHeight)
-        .overlay(alignment: .bottom) {
-            ZStack(alignment: .bottom) {
-                Color.clear
-                    .frame(height: 12)
-                    .contentShape(Rectangle())
-                    .gesture(
-                        DragGesture(minimumDistance: 0)
-                            .onChanged { value in handleResizeDragChanged(value, mode: .bottom) }
-                            .onEnded { value in handleResizeDragEnded(value, mode: .bottom) }
-                    )
-
-                HStack {
-                    Color.clear
-                        .frame(width: 16, height: 16)
-                        .contentShape(Rectangle())
-                        .gesture(
-                            DragGesture(minimumDistance: 0)
-                                .onChanged { value in handleResizeDragChanged(value, mode: .bottomLeading) }
-                                .onEnded { value in handleResizeDragEnded(value, mode: .bottomLeading) }
-                        )
-                    Spacer(minLength: 0)
-                    Color.clear
-                        .frame(width: 16, height: 16)
-                        .contentShape(Rectangle())
-                        .gesture(
-                            DragGesture(minimumDistance: 0)
-                                .onChanged { value in handleResizeDragChanged(value, mode: .bottomTrailing) }
-                                .onEnded { value in handleResizeDragEnded(value, mode: .bottomTrailing) }
-                        )
-                }
-                .frame(height: 16)
-            }
-        }
+        .frame(width: 400, height: 500)
         .sheet(item: $client.pendingApproval) { req in
             ApprovalView(request: req)
                 .environmentObject(client)
@@ -330,7 +288,6 @@ struct ContentView: View {
                     }
                 }
                 .padding()
-                .textSelection(.enabled)
 
                 GeometryReader { geo in
                     Color.clear.preference(
@@ -474,40 +431,6 @@ struct ContentView: View {
         inputText = ""
     }
 
-    private func handleResizeDragChanged(_ value: DragGesture.Value, mode: ResizeDragMode) {
-        guard let window = NSApp.keyWindow else { return }
-        if resizeStartFrame == nil {
-            resizeStartFrame = window.frame
-        }
-        guard let startFrame = resizeStartFrame else { return }
-
-        let targetHeight = max(minWindowHeight, startFrame.height + value.translation.height)
-        let signedHorizontalTranslation: CGFloat
-        switch mode {
-        case .bottom:
-            signedHorizontalTranslation = 0
-        case .bottomLeading:
-            signedHorizontalTranslation = -value.translation.width
-        case .bottomTrailing:
-            signedHorizontalTranslation = value.translation.width
-        }
-        let targetWidth = max(minWindowWidth, startFrame.width + (signedHorizontalTranslation * 2))
-        let maxY = startFrame.maxY
-        let midX = startFrame.midX
-        let newFrame = CGRect(
-            x: midX - (targetWidth / 2),
-            y: maxY - targetHeight,
-            width: targetWidth,
-            height: targetHeight
-        )
-        window.setFrame(newFrame, display: true)
-    }
-
-    private func handleResizeDragEnded(_ value: DragGesture.Value, mode: ResizeDragMode) {
-        handleResizeDragChanged(value, mode: mode)
-        resizeStartFrame = nil
-    }
-
     private func shouldPersistCustomModel(completedEventIndex: Int) -> Bool {
         guard let startIndex = lastRequestStartIndex,
               startIndex <= completedEventIndex,
@@ -550,8 +473,10 @@ struct EventRow: View {
                 .font(.caption)
                 .foregroundColor(.secondary)
                 .italic()
+                .textSelection(.enabled)
         case .assistantMessage(let msg):
             Text(LocalizedStringKey(msg))
+                .textSelection(.enabled)
         case .mcpTool:
             EmptyView()
         case .config:
@@ -560,6 +485,7 @@ struct EventRow: View {
             Text("Settings saved")
                 .font(.caption)
                 .foregroundColor(.green)
+                .textSelection(.enabled)
         case .done:
             Divider()
         case .modelsList:
@@ -577,6 +503,7 @@ struct EventRow: View {
                     .padding(8)
                     .background(Color.accentColor.opacity(0.1))
                     .cornerRadius(8)
+                    .textSelection(.enabled)
             }
         case .approvalRequest(let req):
             let row = HStack(spacing: 6) {

--- a/DragonglassApp/Dragonglass/ContentView.swift
+++ b/DragonglassApp/Dragonglass/ContentView.swift
@@ -252,8 +252,8 @@ struct ContentView: View {
                                 turn: turn,
                                 events: client.events,
                                 detailed: client.detailedToolEvents,
-                                includeToolCalls: includeToolCallsInSelection,
-                                onOpenNote: { client.openNote(path: $0) }
+                                onOpenNote: { client.openNote(path: $0) },
+                                includeToolCalls: includeToolCallsInSelection
                             )
                             if let doneIdx = turn.doneIndex {
                                 EventRow(event: client.events[doneIdx], detailed: client.detailedToolEvents, includeToolCalls: includeToolCallsInSelection)
@@ -267,8 +267,8 @@ struct ContentView: View {
                                     message: m,
                                     detail: d,
                                     detailed: client.detailedToolEvents,
-                                    selectable: includeToolCallsInSelection,
-                                    onOpenNote: { client.openNote(path: $0) }
+                                    onOpenNote: { client.openNote(path: $0) },
+                                    selectable: includeToolCallsInSelection
                                 )
                                     .id(idx)
                                     .transition(.asymmetric(
@@ -651,8 +651,8 @@ struct CollapsedToolSummary: View {
                                 message: m,
                                 detail: d,
                                 detailed: detailed,
-                                selectable: includeToolCalls,
-                                onOpenNote: onOpenNote
+                                onOpenNote: onOpenNote,
+                                selectable: includeToolCalls
                             )
                         }
                     }

--- a/DragonglassApp/Dragonglass/MenuBarManager.swift
+++ b/DragonglassApp/Dragonglass/MenuBarManager.swift
@@ -67,12 +67,12 @@ class MenuBarManager: NSObject, ObservableObject {
                         .environmentObject(client)
                         .environmentObject(sttManager)
                         .environmentObject(hotkeyManager)
-                        .frame(width: 400, height: 500)
                 )
                 hostingController.safeAreaRegions = []
                 let p = NSPopover()
                 p.contentViewController = hostingController
                 p.behavior = .transient
+                p.contentSize = NSSize(width: 400, height: 500)
                 self.popover = p
             }
         } else {
@@ -87,7 +87,10 @@ class MenuBarManager: NSObject, ObservableObject {
         popover.behavior = closeOnFocusLoss ? .semitransient : .transient
         NSApplication.shared.activate(ignoringOtherApps: true)
         popover.show(relativeTo: statusButton.bounds, of: statusButton, preferredEdge: .minY)
-        popover.contentViewController?.view.window?.makeKey()
+        if let window = popover.contentViewController?.view.window {
+            window.minSize = NSSize(width: 400, height: 500)
+            window.makeKey()
+        }
     }
 
     private func updateIcon() {

--- a/DragonglassApp/Dragonglass/MenuBarManager.swift
+++ b/DragonglassApp/Dragonglass/MenuBarManager.swift
@@ -67,12 +67,12 @@ class MenuBarManager: NSObject, ObservableObject {
                         .environmentObject(client)
                         .environmentObject(sttManager)
                         .environmentObject(hotkeyManager)
+                        .frame(width: 400, height: 500)
                 )
                 hostingController.safeAreaRegions = []
                 let p = NSPopover()
                 p.contentViewController = hostingController
                 p.behavior = .transient
-                p.contentSize = NSSize(width: 400, height: 500)
                 self.popover = p
             }
         } else {
@@ -87,10 +87,7 @@ class MenuBarManager: NSObject, ObservableObject {
         popover.behavior = closeOnFocusLoss ? .semitransient : .transient
         NSApplication.shared.activate(ignoringOtherApps: true)
         popover.show(relativeTo: statusButton.bounds, of: statusButton, preferredEdge: .minY)
-        if let window = popover.contentViewController?.view.window {
-            window.minSize = NSSize(width: 400, height: 500)
-            window.makeKey()
-        }
+        popover.contentViewController?.view.window?.makeKey()
     }
 
     private func updateIcon() {

--- a/dragonglass/server/server.py
+++ b/dragonglass/server/server.py
@@ -791,7 +791,7 @@ class DragonglassServer:
         finally:
             logger.info("server: request done")
 
-    async def _run_chat_task(
+    async def _run_chat_task(  # noqa: PLR0915
         self, websocket: typing.Any, data: dict[str, object]
     ) -> None:
         text = str(data.get("text", ""))
@@ -799,6 +799,34 @@ class DragonglassServer:
         model_override = resolve_chat_model(data.get("model"), settings.selected_model)
 
         logger.info("server: chat message: %r (model=%s)", text, model_override)
+
+        provisional_history: list[typing.Any] | None = None
+        if text:
+            if not self._current_conversation_id:
+                self._current_conversation_id = str(uuid.uuid4())
+            if self.agent:
+                provisional_history = [
+                    *self.agent.get_history(),
+                    {"role": "user", "content": text},
+                ]
+            else:
+                provisional_history = [{"role": "user", "content": text}]
+            self._save_conversation(self._current_conversation_id, provisional_history)
+
+        def persist_history() -> None:
+            if not self._current_conversation_id:
+                return
+            latest_history: list[typing.Any] = []
+            if self.agent:
+                latest_history = self.agent.get_history()
+            if provisional_history is not None and len(latest_history) < len(
+                provisional_history
+            ):
+                self._save_conversation(
+                    self._current_conversation_id, provisional_history
+                )
+                return
+            self._save_conversation(self._current_conversation_id, latest_history)
 
         try:
             if not self._agent_ready:
@@ -812,8 +840,6 @@ class DragonglassServer:
                 await websocket.send(serialize_event(DoneEvent()))
                 return
             if self.agent:
-                if not self._current_conversation_id:
-                    self._current_conversation_id = str(uuid.uuid4())
 
                 async def flush_mcp_telemetry() -> None:
                     for telemetry_event in drain_tool_events():
@@ -863,11 +889,10 @@ class DragonglassServer:
                 await flush_mcp_telemetry()
 
                 # Auto-save after response
-                self._save_conversation(
-                    self._current_conversation_id, self.agent.get_history()
-                )  # type: ignore
+                persist_history()
         except asyncio.CancelledError:
             logger.info("server: chat task cancelled")
+            persist_history()
             with contextlib.suppress(Exception):
                 await websocket.send(serialize_event(DoneEvent()))
 


### PR DESCRIPTION
This PR focuses on chat flow and conversation reliability in the Swift app + backend.

## Changes

### Chat UX
- Disabled `New Chat` when the current chat is empty (no turns yet), so we don’t create unnecessary blank chats in [DragonglassApp/Dragonglass/ContentView.swift](DragonglassApp/Dragonglass/ContentView.swift).

### Conversation persistence
- Updated server-side save behavior to persist conversation state on every turn in [dragonglass/server/server.py](dragonglass/server/server.py).
- User messages are now saved immediately, before model processing, in [dragonglass/server/server.py](dragonglass/server/server.py).
- Added fallback persistence on cancellation so partial progress is not lost in [dragonglass/server/server.py](dragonglass/server/server.py).

### Tool call interaction
- Kept the tool call text-selection improvements so users can select and copy tool call data in [DragonglassApp/Dragonglass/ContentView.swift](DragonglassApp/Dragonglass/ContentView.swift).
- Selection behavior still avoids accidental highlighting of UI labels while allowing copy from tool content blocks in [DragonglassApp/Dragonglass/ContentView.swift](DragonglassApp/Dragonglass/ContentView.swift).

Fixes #33