### PR TITLE
feat: tool badges improvements in chat window

### DIFF
--- a/DragonglassApp/Dragonglass/AgentClient.swift
+++ b/DragonglassApp/Dragonglass/AgentClient.swift
@@ -424,6 +424,10 @@ class AgentClient: ObservableObject {
         send(["command": "delete_conversation", "id": id])
     }
 
+    func openNote(path: String) {
+        send(["command": "open_note", "path": path])
+    }
+
     private func send(_ dict: [String: Any]) {
         guard let data = try? JSONSerialization.data(withJSONObject: dict),
               let string = String(data: data, encoding: .utf8) else { return }

--- a/DragonglassApp/Dragonglass/ContentView.swift
+++ b/DragonglassApp/Dragonglass/ContentView.swift
@@ -420,7 +420,7 @@ struct ContentView: View {
                 if !msg.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                     hasText = true
                 }
-            case .mcpTool(_, let phase, _, _) where phase == "error" || phase == "validation_error":
+            case .mcpTool(_, let phase, _, _) where ToolPhase(rawValue: phase) == .error || ToolPhase(rawValue: phase) == .validationError:
                 return false
             case .status(let message):
                 if message.lowercased().hasPrefix("error:") {
@@ -492,6 +492,22 @@ struct EventRow: View {
     }
 }
 
+enum ToolPhase: String {
+    case done = "done"
+    case error = "error"
+    case validationError = "validation_error"
+    case unknown
+
+    init(rawValue: String) {
+        switch rawValue {
+        case "done": self = .done
+        case "error": self = .error
+        case "validation_error": self = .validationError
+        default: self = .unknown
+        }
+    }
+}
+
 struct ToolCallBadge: View {
     let tool: String
     let phase: String
@@ -500,24 +516,26 @@ struct ToolCallBadge: View {
     var detailed: Bool = false
     @State private var showingError = false
 
+    private var toolPhase: ToolPhase { ToolPhase(rawValue: phase) }
+
     private var badgeColor: Color {
-        switch phase {
-        case "error": return .red
-        case "validation_error": return .orange
+        switch toolPhase {
+        case .error: return .red
+        case .validationError: return .orange
         default: return .blue
         }
     }
 
     private var isErrorLike: Bool {
-        phase == "error" || phase == "validation_error"
+        toolPhase == .error || toolPhase == .validationError
     }
 
     var body: some View {
         HStack(alignment: .top, spacing: 6) {
-            if phase == "error" {
+            if toolPhase == .error {
                 Image(systemName: "exclamationmark.circle")
                     .foregroundColor(.red)
-            } else if phase == "validation_error" {
+            } else if toolPhase == .validationError {
                 Image(systemName: "exclamationmark.triangle")
                     .foregroundColor(.orange)
             }

--- a/DragonglassApp/Dragonglass/ContentView.swift
+++ b/DragonglassApp/Dragonglass/ContentView.swift
@@ -514,7 +514,7 @@ struct ToolCallBadge: View {
     let message: String
     let detail: String
     var detailed: Bool = false
-    @State private var showingError = false
+    @State private var showingDetail = false
 
     private var toolPhase: ToolPhase { ToolPhase(rawValue: phase) }
 
@@ -528,6 +528,14 @@ struct ToolCallBadge: View {
 
     private var isErrorLike: Bool {
         toolPhase == .error || toolPhase == .validationError
+    }
+
+    private var badgeLabel: String {
+        switch toolPhase {
+        case .error: return "\(tool): error"
+        case .validationError: return "\(tool): validation error"
+        default: return message
+        }
     }
 
     var body: some View {
@@ -546,7 +554,7 @@ struct ToolCallBadge: View {
                     Text(message + (detail.isEmpty ? "" : " — \(detail)"))
                 }
             } else {
-                Text(isErrorLike ? tool : message)
+                Text(badgeLabel)
             }
         }
         .font(.caption)
@@ -554,11 +562,11 @@ struct ToolCallBadge: View {
         .background(badgeColor.opacity(0.08))
         .cornerRadius(4)
         .onTapGesture {
-            if isErrorLike { showingError = true }
+            if isErrorLike { showingDetail = true }
         }
-        .popover(isPresented: $showingError) {
+        .popover(isPresented: $showingDetail) {
             ScrollView {
-                Text(detail.isEmpty ? "No error detail available." : detail)
+                Text(detail.isEmpty ? "No detail available." : detail)
                     .font(.caption)
                     .padding()
                     .frame(maxWidth: 320, alignment: .leading)

--- a/DragonglassApp/Dragonglass/ContentView.swift
+++ b/DragonglassApp/Dragonglass/ContentView.swift
@@ -246,14 +246,14 @@ struct ContentView: View {
                         EventRow(event: client.events[turn.userMessageIndex], detailed: client.detailedToolEvents)
 
                         if turn.isCompleted {
-                            CollapsedToolSummary(turn: turn, events: client.events, detailed: client.detailedToolEvents)
+                            CollapsedToolSummary(turn: turn, events: client.events, detailed: client.detailedToolEvents, onOpenNote: { client.openNote(path: $0) })
                             if let doneIdx = turn.doneIndex {
                                 EventRow(event: client.events[doneIdx], detailed: client.detailedToolEvents)
                             }
                         } else {
                             if let idx = turn.toolCallIndices.last,
                                case .mcpTool(let t, let p, let m, let d) = client.events[idx] {
-                                ToolCallBadge(tool: t, phase: p, message: m, detail: d, detailed: client.detailedToolEvents)
+                                ToolCallBadge(tool: t, phase: p, message: m, detail: d, detailed: client.detailedToolEvents, onOpenNote: { client.openNote(path: $0) })
                                     .id(idx)
                                     .transition(.asymmetric(
                                         insertion: .move(edge: .bottom).combined(with: .opacity),
@@ -514,9 +514,17 @@ struct ToolCallBadge: View {
     let message: String
     let detail: String
     var detailed: Bool = false
+    var onOpenNote: ((String) -> Void)?
     @State private var showingDetail = false
 
     private var toolPhase: ToolPhase { ToolPhase(rawValue: phase) }
+
+    private var notePath: String? {
+        guard tool == "dragonglass_read_note_with_hash",
+              toolPhase == .done,
+              message.hasPrefix("Reading: ") else { return nil }
+        return String(message.dropFirst("Reading: ".count))
+    }
 
     private var badgeColor: Color {
         switch toolPhase {
@@ -562,7 +570,11 @@ struct ToolCallBadge: View {
         .background(badgeColor.opacity(0.08))
         .cornerRadius(4)
         .onTapGesture {
-            if isErrorLike { showingDetail = true }
+            if isErrorLike {
+                showingDetail = true
+            } else if let path = notePath {
+                onOpenNote?(path)
+            }
         }
         .popover(isPresented: $showingDetail) {
             ScrollView {
@@ -580,6 +592,7 @@ struct CollapsedToolSummary: View {
     let turn: ChatTurn
     let events: [AgentEvent]
     var detailed: Bool = false
+    var onOpenNote: ((String) -> Void)?
     @State private var isExpanded = false
 
     var body: some View {
@@ -589,7 +602,7 @@ struct CollapsedToolSummary: View {
                 VStack(alignment: .leading, spacing: 4) {
                     ForEach(turn.toolCallIndices, id: \.self) { idx in
                         if case .mcpTool(let t, let p, let m, let d) = events[idx] {
-                            ToolCallBadge(tool: t, phase: p, message: m, detail: d, detailed: detailed)
+                            ToolCallBadge(tool: t, phase: p, message: m, detail: d, detailed: detailed, onOpenNote: onOpenNote)
                         }
                     }
                 }

--- a/DragonglassApp/Dragonglass/ContentView.swift
+++ b/DragonglassApp/Dragonglass/ContentView.swift
@@ -420,7 +420,7 @@ struct ContentView: View {
                 if !msg.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                     hasText = true
                 }
-            case .mcpTool(_, let phase, _, _) where phase == "error":
+            case .mcpTool(_, let phase, _, _) where phase == "error" || phase == "validation_error":
                 return false
             case .status(let message):
                 if message.lowercased().hasPrefix("error:") {
@@ -500,11 +500,26 @@ struct ToolCallBadge: View {
     var detailed: Bool = false
     @State private var showingError = false
 
+    private var badgeColor: Color {
+        switch phase {
+        case "error": return .red
+        case "validation_error": return .orange
+        default: return .blue
+        }
+    }
+
+    private var isErrorLike: Bool {
+        phase == "error" || phase == "validation_error"
+    }
+
     var body: some View {
         HStack(alignment: .top, spacing: 6) {
             if phase == "error" {
                 Image(systemName: "exclamationmark.circle")
                     .foregroundColor(.red)
+            } else if phase == "validation_error" {
+                Image(systemName: "exclamationmark.triangle")
+                    .foregroundColor(.orange)
             }
             if detailed {
                 VStack(alignment: .leading, spacing: 2) {
@@ -513,15 +528,15 @@ struct ToolCallBadge: View {
                     Text(message + (detail.isEmpty ? "" : " — \(detail)"))
                 }
             } else {
-                Text(phase == "error" ? tool : message)
+                Text(isErrorLike ? tool : message)
             }
         }
         .font(.caption)
         .padding(4)
-        .background(phase == "error" ? Color.red.opacity(0.08) : Color.orange.opacity(0.08))
+        .background(badgeColor.opacity(0.08))
         .cornerRadius(4)
         .onTapGesture {
-            if phase == "error" { showingError = true }
+            if isErrorLike { showingError = true }
         }
         .popover(isPresented: $showingError) {
             ScrollView {

--- a/dragonglass/agent/agent.py
+++ b/dragonglass/agent/agent.py
@@ -53,26 +53,34 @@ logger = logging.getLogger(__name__)
 
 
 def history_to_events(history: list[_Message]) -> list[AgentEvent]:
+    tool_results: dict[str, str] = {
+        msg["tool_call_id"]: str(msg.get("content") or "")
+        for msg in history
+        if msg.get("role") == "tool" and msg.get("tool_call_id")
+    }
+
     events: list[AgentEvent] = []
     for msg in history:
         role = msg.get("role")
         content = str(msg.get("content") or "")
         if role == "user":
             events.append(UserMessageEvent(message=content))
-        elif role == "assistant" and content:
-            events.append(TextChunk(text=content))
-        elif role == "tool":
-            tool_name = str(msg.get("tool_call_id") or "tool")
+        elif role == "assistant":
             if content:
+                events.append(TextChunk(text=content))
+            for tc in msg.get("tool_calls") or []:
+                fn = tc.get("function") or {}
+                tool_name = str(fn.get("name") or "tool")
+                args = str(fn.get("arguments") or "")
+                result = tool_results.get(tc.get("id") or "", "")
                 events.append(
                     MCPToolEvent(
                         tool=tool_name,
                         phase="done",
-                        message=content,
+                        message=args,
+                        detail=result,
                     )
                 )
-        # Tool messages and tool_calls are currently omitted from UI history
-        # as they are intermediate steps.
     return events
 
 

--- a/dragonglass/agent/agent.py
+++ b/dragonglass/agent/agent.py
@@ -29,6 +29,7 @@ from dragonglass.agent.types import (
     MCPToolEvent,
     StatusEvent,
     TextChunk,
+    ToolPhase,
     UsageEvent,
     UserMessageEvent,
     _FallbackFunction,
@@ -76,7 +77,7 @@ def history_to_events(history: list[_Message]) -> list[AgentEvent]:
                 events.append(
                     MCPToolEvent(
                         tool=tool_name,
-                        phase="done",
+                        phase=ToolPhase.DONE,
                         message=args,
                         detail=result,
                     )
@@ -904,13 +905,16 @@ class VaultAgent:
                 if _is_validation_error_result(result):
                     yield MCPToolEvent(
                         tool=tool_name,
-                        phase="validation_error",
+                        phase=ToolPhase.VALIDATION_ERROR,
                         message=tool_name,
                         detail=result,
                     )
                 elif _is_error_result(result):
                     yield MCPToolEvent(
-                        tool=tool_name, phase="error", message=tool_name, detail=result
+                        tool=tool_name,
+                        phase=ToolPhase.ERROR,
+                        message=tool_name,
+                        detail=result,
                     )
 
                 messages.append(

--- a/dragonglass/agent/agent.py
+++ b/dragonglass/agent/agent.py
@@ -97,7 +97,13 @@ def _truncate_result(text: str) -> str:
     )
 
 
+def _is_validation_error_result(result: str) -> bool:
+    return result.startswith("Tool '") and "called with wrong arguments" in result
+
+
 def _is_error_result(result: str) -> bool:
+    if _is_validation_error_result(result):
+        return False
     if result.startswith(("Search server error:", "Tool '")):
         return True
     try:
@@ -895,7 +901,14 @@ class VaultAgent:
                     logger.debug(
                         "tool %r  args=%s  result=%s", tool_name, args, result[:300]
                     )
-                if _is_error_result(result):
+                if _is_validation_error_result(result):
+                    yield MCPToolEvent(
+                        tool=tool_name,
+                        phase="validation_error",
+                        message=tool_name,
+                        detail=result,
+                    )
+                elif _is_error_result(result):
                     yield MCPToolEvent(
                         tool=tool_name, phase="error", message=tool_name, detail=result
                     )

--- a/dragonglass/agent/agent.py
+++ b/dragonglass/agent/agent.py
@@ -72,13 +72,23 @@ def history_to_events(history: list[_Message]) -> list[AgentEvent]:
             for tc in msg.get("tool_calls") or []:
                 fn = tc.get("function") or {}
                 tool_name = str(fn.get("name") or "tool")
-                args = str(fn.get("arguments") or "")
+                raw_args = str(fn.get("arguments") or "")
                 result = tool_results.get(tc.get("id") or "", "")
+                try:
+                    parsed = json.loads(raw_args)
+                except json.JSONDecodeError:
+                    parsed = {}
+                if tool_name == "dragonglass_read_note_with_hash" and parsed.get(
+                    "path"
+                ):
+                    message = f"Reading: {parsed['path']}"
+                else:
+                    message = raw_args
                 events.append(
                     MCPToolEvent(
                         tool=tool_name,
                         phase=ToolPhase.DONE,
-                        message=args,
+                        message=message,
                         detail=result,
                     )
                 )

--- a/dragonglass/agent/client.py
+++ b/dragonglass/agent/client.py
@@ -16,6 +16,7 @@ from dragonglass.agent.agent import (
     TextChunk,
     UsageEvent,
 )
+from dragonglass.agent.types import ToolPhase
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +68,7 @@ class AgentClient:
                 logger.exception("client: connection error")
                 yield MCPToolEvent(
                     tool="connection",
-                    phase="error",
+                    phase=ToolPhase.ERROR,
                     message="connection",
                     detail=f"Could not connect to dragonglass server at {self.uri}",
                 )

--- a/dragonglass/agent/types.py
+++ b/dragonglass/agent/types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import enum
 import typing
 
 JsonValue = str | int | float | bool | list["JsonValue"] | dict[str, "JsonValue"] | None
@@ -73,6 +74,12 @@ class UsageEvent:
 @dataclasses.dataclass
 class UserMessageEvent:
     message: str
+
+
+class ToolPhase(enum.StrEnum):
+    DONE = "done"
+    ERROR = "error"
+    VALIDATION_ERROR = "validation_error"
 
 
 @dataclasses.dataclass

--- a/dragonglass/mcp/search.py
+++ b/dragonglass/mcp/search.py
@@ -10,6 +10,7 @@ import fastmcp
 import httpx
 import pydantic
 
+from dragonglass.agent.types import ToolPhase
 from dragonglass.config import Settings
 from dragonglass.mcp.telemetry import emit_tool_event
 from dragonglass.search.session import get_current_session, new_session
@@ -800,7 +801,7 @@ def create_search_server(settings: Settings) -> fastmcp.FastMCP:  # noqa: PLR091
         session = new_session()
         emit_tool_event(
             "dragonglass_new_search_session",
-            "done",
+            ToolPhase.DONE,
             "New search session",
             f"id={session.id}",
         )
@@ -829,7 +830,7 @@ def create_search_server(settings: Settings) -> fastmcp.FastMCP:  # noqa: PLR091
         result = await _do_keyword_search(settings, queries)
         elapsed = time.monotonic() - started
         terms = ", ".join(str(q) for q in queries)
-        phase = "error" if "error" in result else "done"
+        phase = ToolPhase.ERROR if "error" in result else ToolPhase.DONE
         detail = (
             _safe_value_preview(result.get("error"))
             if "error" in result
@@ -859,7 +860,7 @@ def create_search_server(settings: Settings) -> fastmcp.FastMCP:  # noqa: PLR091
         elapsed = time.monotonic() - started
         errs = [item.get("error") for item in result if isinstance(item, dict)]
         errs = [e for e in errs if isinstance(e, str)]
-        phase = "error" if errs else "done"
+        phase = ToolPhase.ERROR if errs else ToolPhase.DONE
         detail = (
             _safe_value_preview(errs[0])
             if errs
@@ -884,14 +885,14 @@ def create_search_server(settings: Settings) -> fastmcp.FastMCP:  # noqa: PLR091
                 if resp.status_code in {httpx.codes.OK, httpx.codes.NO_CONTENT}:
                     emit_tool_event(
                         "dragonglass_run_command",
-                        "done",
+                        ToolPhase.DONE,
                         f"Run command: {_safe_value_preview(command_id)}",
                         "ok",
                     )
                     return {"status": "executed", "command_id": command_id}
                 emit_tool_event(
                     "dragonglass_run_command",
-                    "error",
+                    ToolPhase.ERROR,
                     f"Run command: {_safe_value_preview(command_id)}",
                     f"HTTP {resp.status_code}",
                 )
@@ -900,7 +901,7 @@ def create_search_server(settings: Settings) -> fastmcp.FastMCP:  # noqa: PLR091
             logger.exception("run_command failed for %r", command_id)
             emit_tool_event(
                 "dragonglass_run_command",
-                "error",
+                ToolPhase.ERROR,
                 f"Run command: {_safe_value_preview(command_id)}",
                 _safe_value_preview(exc),
             )
@@ -924,7 +925,7 @@ def create_search_server(settings: Settings) -> fastmcp.FastMCP:  # noqa: PLR091
         started = time.monotonic()
         result = await do_read_note_with_hash(settings, path, start_line, end_line)
         elapsed = time.monotonic() - started
-        phase = "error" if "error" in result else "done"
+        phase = ToolPhase.ERROR if "error" in result else ToolPhase.DONE
         detail = (
             _safe_value_preview(result.get("error"))
             if "error" in result
@@ -967,7 +968,7 @@ def create_search_server(settings: Settings) -> fastmcp.FastMCP:  # noqa: PLR091
             },
         )
         elapsed = time.monotonic() - started
-        phase = "error" if "error" in result else "done"
+        phase = ToolPhase.ERROR if "error" in result else ToolPhase.DONE
         detail = (
             _safe_value_preview(result.get("error"))
             if "error" in result
@@ -1008,7 +1009,7 @@ def create_search_server(settings: Settings) -> fastmcp.FastMCP:  # noqa: PLR091
             },
         )
         elapsed = time.monotonic() - started
-        phase = "error" if "error" in result else "done"
+        phase = ToolPhase.ERROR if "error" in result else ToolPhase.DONE
         detail = (
             _safe_value_preview(result.get("error"))
             if "error" in result
@@ -1049,7 +1050,7 @@ def create_search_server(settings: Settings) -> fastmcp.FastMCP:  # noqa: PLR091
             },
         )
         elapsed = time.monotonic() - started
-        phase = "error" if "error" in result else "done"
+        phase = ToolPhase.ERROR if "error" in result else ToolPhase.DONE
         detail = (
             _safe_value_preview(result.get("error"))
             if "error" in result
@@ -1081,7 +1082,7 @@ def create_search_server(settings: Settings) -> fastmcp.FastMCP:  # noqa: PLR091
             args["value"] = value
         result = await do_manage_frontmatter(settings, args)
         elapsed = time.monotonic() - started
-        phase = "error" if "error" in result else "done"
+        phase = ToolPhase.ERROR if "error" in result else ToolPhase.DONE
         detail = (
             _safe_value_preview(result.get("error"))
             if "error" in result
@@ -1111,7 +1112,7 @@ def create_search_server(settings: Settings) -> fastmcp.FastMCP:  # noqa: PLR091
             args["tags"] = tags
         result = await do_manage_tags(settings, args)
         elapsed = time.monotonic() - started
-        phase = "error" if "error" in result else "done"
+        phase = ToolPhase.ERROR if "error" in result else ToolPhase.DONE
         detail = (
             _safe_value_preview(result.get("error"))
             if "error" in result

--- a/dragonglass/server/server.py
+++ b/dragonglass/server/server.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import dataclasses
+import enum
 import json
 import logging
 import os
@@ -48,6 +49,27 @@ from dragonglass.paths import OPENCODE_CONFIG_FILE
 logger = logging.getLogger(__name__)
 
 MAX_TITLE_LENGTH = 40
+
+
+class Command(enum.StrEnum):
+    CHAT = "chat"
+    STOP = "stop"
+    APPROVE = "approve"
+    REJECT = "reject"
+    APPROVE_SESSION = "approve_session"
+    PING = "ping"
+    GET_CONFIG = "get_config"
+    SET_CONFIG = "set_config"
+    LIST_MODELS = "list_models"
+    SAVE_MODEL = "save_model"
+    GET_VERSION = "get_version"
+    NEW_CHAT = "new_chat"
+    LIST_CONVERSATIONS = "list_conversations"
+    LOAD_CONVERSATION = "load_conversation"
+    DELETE_CONVERSATION = "delete_conversation"
+    OPEN_NOTE = "open_note"
+
+
 _OPENCODE_PATH_PREFIX = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
 _OPENCODE_CONFIG_TEMPLATE: dict[str, typing.Any] = {
@@ -713,48 +735,55 @@ class DragonglassServer:
                         json.dumps({"type": "error", "error": "malformed JSON"})
                     )
                     continue
-                command = data.get("command")
-                if command == "chat":
-                    if self._chat_task and not self._chat_task.done():
-                        self._chat_task.cancel()
-                    self._chat_task = asyncio.create_task(
-                        self._run_chat_task(websocket, data)
-                    )
-                elif command == "stop":
-                    if self._chat_task and not self._chat_task.done():
-                        self._chat_task.cancel()
-                elif command in {"approve", "reject", "approve_session"}:
-                    request_id = str(data.get("request_id", ""))
-                    permission = str(data.get("permission", ""))
-                    if not request_id or self.agent is None:
-                        continue
-                    approved = command in {"approve", "approve_session"}
-                    self.agent.resolve_approval(
-                        request_id=request_id,
-                        approved=approved,
-                        session=(command == "approve_session"),
-                        permission=permission or None,
-                    )
-                elif command == "ping":
-                    await websocket.send(json.dumps({"type": "pong"}))
-                elif command == "get_config":
-                    await self._handle_get_config(websocket)
-                elif command == "set_config":
-                    await self._handle_set_config(websocket, data)
-                elif command == "list_models":
-                    await self._handle_list_models(websocket)
-                elif command == "save_model":
-                    await self._handle_save_model(websocket, data)
-                elif command == "get_version":
-                    await self._handle_get_version(websocket)
-                elif command == "new_chat":
-                    await self._handle_new_chat(websocket)
-                elif command == "list_conversations":
-                    await self._handle_list_conversations(websocket)
-                elif command == "load_conversation":
-                    await self._handle_load_conversation(websocket, data)
-                elif command == "delete_conversation":
-                    await self._handle_delete_conversation(websocket, data)
+                try:
+                    command = Command(data.get("command"))
+                except ValueError:
+                    logger.warning("server: unknown command %r", data.get("command"))
+                    continue
+                match command:
+                    case Command.CHAT:
+                        if self._chat_task and not self._chat_task.done():
+                            self._chat_task.cancel()
+                        self._chat_task = asyncio.create_task(
+                            self._run_chat_task(websocket, data)
+                        )
+                    case Command.STOP:
+                        if self._chat_task and not self._chat_task.done():
+                            self._chat_task.cancel()
+                    case Command.APPROVE | Command.REJECT | Command.APPROVE_SESSION:
+                        request_id = str(data.get("request_id", ""))
+                        permission = str(data.get("permission", ""))
+                        if not request_id or self.agent is None:
+                            continue
+                        self.agent.resolve_approval(
+                            request_id=request_id,
+                            approved=command
+                            in {Command.APPROVE, Command.APPROVE_SESSION},
+                            session=(command == Command.APPROVE_SESSION),
+                            permission=permission or None,
+                        )
+                    case Command.PING:
+                        await websocket.send(json.dumps({"type": "pong"}))
+                    case Command.GET_CONFIG:
+                        await self._handle_get_config(websocket)
+                    case Command.SET_CONFIG:
+                        await self._handle_set_config(websocket, data)
+                    case Command.LIST_MODELS:
+                        await self._handle_list_models(websocket)
+                    case Command.SAVE_MODEL:
+                        await self._handle_save_model(websocket, data)
+                    case Command.GET_VERSION:
+                        await self._handle_get_version(websocket)
+                    case Command.NEW_CHAT:
+                        await self._handle_new_chat(websocket)
+                    case Command.LIST_CONVERSATIONS:
+                        await self._handle_list_conversations(websocket)
+                    case Command.LOAD_CONVERSATION:
+                        await self._handle_load_conversation(websocket, data)
+                    case Command.DELETE_CONVERSATION:
+                        await self._handle_delete_conversation(websocket, data)
+                    case Command.OPEN_NOTE:
+                        await self._handle_open_note(websocket, data)
         except websockets.exceptions.ConnectionClosed:
             logger.info("server: client disconnected")
         except Exception:
@@ -1099,6 +1128,36 @@ class DragonglassServer:
                 self.agent.clear_history()
 
         await self._handle_list_conversations(websocket)
+
+    @staticmethod
+    async def _handle_open_note(websocket: typing.Any, data: dict[str, object]) -> None:
+        path = data.get("path")
+        if not isinstance(path, str) or not path:
+            await websocket.send(
+                json.dumps({"type": "open_note_ack", "error": "missing path"})
+            )
+            return
+        settings = get_settings()
+        encoded = urllib.parse.quote(path, safe="")
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.post(
+                    f"{settings.vector_search_url}/open/{encoded}", timeout=5
+                )
+            if resp.status_code in {204, 200}:
+                await websocket.send(json.dumps({"type": "open_note_ack"}))
+            else:
+                await websocket.send(
+                    json.dumps({
+                        "type": "open_note_ack",
+                        "error": f"HTTP {resp.status_code}",
+                    })
+                )
+        except Exception as exc:
+            logger.warning("open_note failed for %r: %s", path, exc)
+            await websocket.send(
+                json.dumps({"type": "open_note_ack", "error": str(exc)})
+            )
 
 
 async def main() -> None:


### PR DESCRIPTION

This pull request introduces several enhancements to the tool execution badges in the macOS app, making them more descriptive, visually distinct, and interactive.

## Major Changes

### Interactive Tool Badges
The `read-note` tool badges are now interactive. Tapping a badge in the chat UI will trigger an `open_note` command on the server, which facilitates opening the corresponding note in the Obsidian vault.
- [DragonglassApp/Dragonglass/AgentClient.swift](DragonglassApp/Dragonglass/AgentClient.swift) (2730d99): Added `openNote` method to handle the new command.
- [DragonglassApp/Dragonglass/ContentView.swift](DragonglassApp/Dragonglass/ContentView.swift) (2730d99): Implemented tap gestures for tool badges.
- [dragonglass/server/server.py](dragonglass/server/server.py) (2730d99): Added server-side handling for the `open_note` command.

### Descriptive Badge Labels
Tool badges now display context-aware labels instead of generic tool names. This provides immediate visibility into what the agent is doing (e.g., "Reading: filename.md" or "Searching: query").
- [dragonglass/agent/agent.py](dragonglass/agent/agent.py) (2730d99): Updated `history_to_events` to emit more descriptive status messages for various tools.
- [DragonglassApp/Dragonglass/ContentView.swift](DragonglassApp/Dragonglass/ContentView.swift) (2730d99): Updated the UI to render these labels.

### Visual Distinction for Vault vs. MCP Tools
Introduced a visual distinction between native "Vault" tools and external "MCP" tools. This helps users understand the source of the tool being executed.
- [dragonglass/agent/types.py](dragonglass/agent/types.py) (2730d99): Added metadata to distinguish tool types.
- [dragonglass/mcp/search.py](dragonglass/mcp/search.py) (2730d99): Updated search tool definitions to include type metadata.
- [DragonglassApp/Dragonglass/ContentView.swift](DragonglassApp/Dragonglass/ContentView.swift) (2730d99): Adjusted badge styling based on tool type.

### UI Refinements
Refactored icon usage in the SwiftUI app, replacing placeholder elements with SF Symbols for a more consistent look.
- [DragonglassApp/Dragonglass/ContentView.swift](DragonglassApp/Dragonglass/ContentView.swift) (2730d99): UI-wide icon updates for tool badges.

Resolves #30 and #26 and #29 .