### PR TITLE
Add resend button for cancelled chat messages

### DIFF
--- a/DragonglassApp/Dragonglass/ContentView.swift
+++ b/DragonglassApp/Dragonglass/ContentView.swift
@@ -245,7 +245,23 @@ struct ContentView: View {
                     }
 
                     ForEach(client.turns) { turn in
-                        EventRow(event: client.events[turn.userMessageIndex], detailed: client.detailedToolEvents, includeToolCalls: includeToolCallsInSelection)
+                        if !turn.isCompleted, case .userMessage(let msg) = client.events[turn.userMessageIndex] {
+                            HStack(alignment: .top, spacing: 4) {
+                                Button(action: {
+                                    inputText = msg
+                                }) {
+                                    Image(systemName: "arrow.counterclockwise")
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                        .padding(4)
+                                }
+                                .buttonStyle(.plain)
+                                .help("Resend message")
+                                EventRow(event: client.events[turn.userMessageIndex], detailed: client.detailedToolEvents, includeToolCalls: includeToolCallsInSelection)
+                            }
+                        } else {
+                            EventRow(event: client.events[turn.userMessageIndex], detailed: client.detailedToolEvents, includeToolCalls: includeToolCallsInSelection)
+                        }
 
                         if turn.isCompleted {
                             CollapsedToolSummary(


### PR DESCRIPTION
When a user cancels a running chat, the message stays in history but the turn remains incomplete. Add a resend button (arrow.counterclockwise icon) next to user message bubbles to let users restore the message text back into the input field and re-send it without retyping.