### PR TITLE
feat(mcp): add dragonglass_get_date_context tool

### DIFF
--- a/dragonglass/agent/approval.py
+++ b/dragonglass/agent/approval.py
@@ -17,6 +17,7 @@ class DragonglassTool(enum.StrEnum):
     MANAGE_FRONTMATTER = "dragonglass_manage_frontmatter"
     MANAGE_TAGS = "dragonglass_manage_tags"
     NEW_SEARCH_SESSION = "dragonglass_new_search_session"
+    GET_DATE_CONTEXT = "dragonglass_get_date_context"
     KEYWORD_SEARCH = "dragonglass_keyword_search"
     VECTOR_SEARCH = "dragonglass_vector_search"
     RUN_COMMAND = "dragonglass_run_command"

--- a/dragonglass/agent/runtime.py
+++ b/dragonglass/agent/runtime.py
@@ -65,6 +65,7 @@ _TOOL_STATUS: dict[str, str] = {
 
 _SEARCH_TOOLS: frozenset[str] = frozenset({
     DragonglassTool.NEW_SEARCH_SESSION,
+    DragonglassTool.GET_DATE_CONTEXT,
     DragonglassTool.KEYWORD_SEARCH,
     DragonglassTool.VECTOR_SEARCH,
     DragonglassTool.RUN_COMMAND,

--- a/dragonglass/agent/system_prompt.md
+++ b/dragonglass/agent/system_prompt.md
@@ -17,6 +17,8 @@ Core rules:
 
 Always search before answering or making changes. Follow this order:
 
+**Step 0 — `dragonglass_get_date_context`** (when needed). If the query involves a relative or ambiguous date ("next Sunday", "last week", "yesterday", a month and day without a year), call this first to get the concrete ISO dates before searching.
+
 **Step 1 — `dragonglass_new_search_session`** (mandatory). `dragonglass_keyword_search` and `dragonglass_vector_search` require an active session.
 
 **Step 2 — `dragonglass_keyword_search`**
@@ -70,6 +72,8 @@ For edits inside an existing file, follow this flow:
 - Use `dragonglass_manage_frontmatter` for get/set/delete operations.
 
 ## Tool Reference
+
+**`dragonglass_get_date_context`** — returns today's date and a week calendar anchored at today + `offset_days` (default 0). Use to resolve relative date expressions: pass `-7` for last week, `+7` for next week, `-14` for two weeks ago, etc.
 
 **`dragonglass_read_note_with_hash`** — returns content with line numbers (e.g., `L10: content`) and captures the hash of the ENTIRE file. Use optional `start_line` and `end_line` for targeted reading or verification.
 

--- a/dragonglass/mcp/search/tools.py
+++ b/dragonglass/mcp/search/tools.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 import logging
 import time
 import typing
@@ -49,6 +50,43 @@ def create_search_server(settings: Settings) -> fastmcp.FastMCP:  # noqa: PLR091
             f"id={session.id}",
         )
         return {"session_id": session.id, "status": "created"}
+
+    @m.tool(name="dragonglass_get_date_context")
+    def get_date_context(
+        offset_days: int = 0,
+    ) -> dict[str, str | list[dict[str, str]]]:
+        """Return the date, day of week, and week calendar anchored at today + offset_days.
+
+        Call this when the user refers to dates relatively (e.g. "next Sunday",
+        "last week", "yesterday") so you can resolve the correct ISO date before
+        searching the vault. Use offset_days to shift the anchor: -7 for last week,
+        +7 for next week, -14 for two weeks ago, etc.
+        """
+        day_names = [
+            "Monday",
+            "Tuesday",
+            "Wednesday",
+            "Thursday",
+            "Friday",
+            "Saturday",
+            "Sunday",
+        ]
+        today = datetime.date.today()
+        anchor = today + datetime.timedelta(days=offset_days)
+        monday = anchor - datetime.timedelta(days=anchor.weekday())
+        week = [
+            {
+                "day": day_names[i],
+                "date": (monday + datetime.timedelta(days=i)).isoformat(),
+            }
+            for i in range(7)
+        ]
+        return {
+            "today": today.isoformat(),
+            "anchor": anchor.isoformat(),
+            "day_of_week": day_names[anchor.weekday()],
+            "week": week,
+        }
 
     @m.tool(name="dragonglass_keyword_search")
     async def keyword_search(


### PR DESCRIPTION
This PR introduces the `dragonglass_get_date_context` tool to the MCP search server and integrates it into the agent's core workflow. This tool enables the model to resolve relative or ambiguous date expressions (e.g., "next Sunday", "last week", "yesterday") into concrete ISO-8601 dates, ensuring more accurate vault searches for time-sensitive queries.

## Major Changes

### MCP Search Server
- **New Tool**: Implemented `dragonglass_get_date_context` in [dragonglass/mcp/search/tools.py](dragonglass/mcp/search/tools.py#e7b5a069f069d737b2d85df34891eb739f7c47ee).
    - Returns today's ISO date, an anchor date (shifted by an optional `offset_days`), the day of the week, and a full calendar for the anchor week.
    - Provides a robust mechanism for the agent to anchor relative time expressions without relying on hardcoded windows or system clock assumptions.

### Vault Agent
- **Workflow Integration**: Updated the core search rhythm in [dragonglass/agent/system_prompt.md](dragonglass/agent/system_prompt.md#e7b5a069f069d737b2d85df34891eb739f7c47ee) to include a "Step 0" for date context retrieval.
    - The agent is now directed to call this tool whenever a query involves relative or ambiguous date terms.
- **Runtime Configuration**:
    - Added the tool to the `_SEARCH_TOOLS` set in [dragonglass/agent/runtime.py](dragonglass/agent/runtime.py#e7b5a069f069d737b2d85df34891eb739f7c47ee).
    - Registered `GET_DATE_CONTEXT` in the `DragonglassTool` enum within [dragonglass/agent/approval.py](dragonglass/agent/approval.py#e7b5a069f069d737b2d85df34891eb739f7c47ee) for proper tool dispatching and approval gating.


Fixes #49.