### PR TITLE
fix: MCP argument validation and coercion

### DIFF
--- a/dragonglass/agent/parsing.py
+++ b/dragonglass/agent/parsing.py
@@ -38,41 +38,9 @@ def _fmt_args(args: dict[str, JsonValue]) -> str:
     return ", ".join(f"{k}={json.dumps(v)}" for k, v in args.items())
 
 
-_RX_MISSING_PARAM = re.compile(
-    r"(?:missing|required) (?:argument|parameter)[:\s]+['\"]?([a-zA-Z0-9_]+)['\"]?|"
-    r"['\"]?([a-zA-Z0-9_]+)['\"]? (?:argument|parameter)?\s*(?:is|missing) required",
-    re.IGNORECASE,
-)
-
 _RX_TOOL_CALL_BLOCK = re.compile(r"<tool_call>(.*?)</tool_call>", re.DOTALL)
 _RX_TOOL_CALL_FN = re.compile(r"<function=([^>]+)>")
 _RX_TOOL_CALL_PARAM = re.compile(r"<parameter=([^>]+)>(.*?)</parameter>", re.DOTALL)
-
-
-def _extract_tool_errors(msg: str) -> str | None:
-    """Extract descriptive error messages from FastMCP/Pydantic validation errors."""
-    lines = msg.splitlines()
-    for i, line in enumerate(lines):
-        lowered = line.lower()
-        matches = [m for group in _RX_MISSING_PARAM.findall(line) for m in group if m]
-        if matches:
-            return f"Missing required parameter(s): {', '.join(matches)}"
-
-        if (
-            any(
-                kw in lowered
-                for kw in ("input should be", "missing required", "field required")
-            )
-            and i > 0
-            and (param := lines[i - 1].strip())
-            and " " not in param
-            and not param.endswith("]")
-        ):
-            if "missing" in lowered or ("required" in lowered and "field" in lowered):
-                return f"Missing required parameter: '{param}'"
-            return f"Parameter '{param}' is invalid: {line.strip()}"
-
-    return None
 
 
 def parse_tool_calls_from_text(

--- a/dragonglass/agent/runtime.py
+++ b/dragonglass/agent/runtime.py
@@ -182,6 +182,167 @@ def _coerce_json_map(value: JsonValue) -> dict[str, JsonValue]:
     return result
 
 
+_PATH_ALIASES: frozenset[str] = frozenset({
+    "filePath",
+    "file_path",
+    "file",
+    "note",
+    "notePath",
+    "note_path",
+})
+
+_KEYWORD_QUERIES_ALIASES: frozenset[str] = frozenset({
+    "queryStrings",
+    "query_strings",
+    "keywords",
+    "searchTerms",
+    "search_terms",
+    "terms",
+    "searches",
+})
+
+_VECTOR_QUERY_ALIASES: frozenset[str] = frozenset({
+    "queryString",
+    "query_string",
+    "searchQuery",
+    "search_query",
+    "search",
+    "text",
+})
+
+_TOP_N_ALIASES: frozenset[str] = frozenset({
+    "topN",
+    "top_k",
+    "topK",
+    "k",
+    "n",
+    "limit",
+    "max_results",
+})
+
+_MIN_SCORE_ALIASES: frozenset[str] = frozenset({
+    "minScore",
+    "min_score",
+    "threshold",
+    "score",
+    "min_similarity",
+})
+
+_PATH_TOOLS: frozenset[str] = frozenset({
+    DragonglassTool.READ_NOTE_WITH_HASH,
+    DragonglassTool.REPLACE_LINES,
+    DragonglassTool.INSERT_AFTER_LINE,
+    DragonglassTool.DELETE_LINES,
+    DragonglassTool.MANAGE_FRONTMATTER,
+    DragonglassTool.MANAGE_TAGS,
+})
+
+_START_LINE_ALIASES: frozenset[str] = frozenset({
+    "startLine",
+    "start_line",
+    "start",
+    "from",
+    "from_line",
+    "fromLine",
+})
+
+_END_LINE_ALIASES: frozenset[str] = frozenset({
+    "endLine",
+    "end_line",
+    "end",
+    "to",
+    "to_line",
+    "toLine",
+})
+
+_REPLACEMENT_ALIASES: frozenset[str] = frozenset({
+    "content",
+    "new_content",
+    "newContent",
+    "new_text",
+    "newText",
+    "new_lines",
+    "newLines",
+})
+
+_LINE_ALIASES: frozenset[str] = frozenset({
+    "lineNumber",
+    "line_number",
+    "after_line",
+    "afterLine",
+    "lineNum",
+    "line_num",
+})
+
+_TEXT_ALIASES: frozenset[str] = frozenset({
+    "content",
+    "new_content",
+    "newContent",
+    "new_text",
+    "newText",
+})
+
+_OPERATION_ALIASES: frozenset[str] = frozenset({"op", "action", "type"})
+
+
+def _rename_first(
+    args: dict[str, JsonValue], aliases: frozenset[str], target: str
+) -> None:
+    """Rename the first alias found into target, only if target is absent."""
+    if target in args:
+        return
+    for alias in aliases:
+        if alias in args:
+            logger.debug("coercing arg %r → %r", alias, target)
+            args[target] = args.pop(alias)
+            return
+
+
+def _coerce_args(name: str, args: dict[str, JsonValue]) -> None:
+    if name in _PATH_TOOLS:
+        _rename_first(args, _PATH_ALIASES, "path")
+
+    if name == DragonglassTool.KEYWORD_SEARCH:
+        _rename_first(args, _KEYWORD_QUERIES_ALIASES, "queries")
+        queries = args.get("queries")
+        if isinstance(queries, str):
+            parts: list[JsonValue] = [
+                p.strip() for p in queries.split(",") if p.strip()
+            ]
+            args["queries"] = parts if len(parts) > 1 else [queries.strip()]
+        elif isinstance(queries, list):
+            flat: list[JsonValue] = []
+            for item in queries:
+                if isinstance(item, str) and "," in item:
+                    flat.extend(p.strip() for p in item.split(",") if p.strip())
+                else:
+                    flat.append(item)
+            args["queries"] = flat
+
+    if name == DragonglassTool.VECTOR_SEARCH:
+        _rename_first(args, _VECTOR_QUERY_ALIASES, "query")
+        _rename_first(args, _TOP_N_ALIASES, "top_n")
+        _rename_first(args, _MIN_SCORE_ALIASES, "min_score")
+
+    if name in {
+        DragonglassTool.REPLACE_LINES,
+        DragonglassTool.DELETE_LINES,
+        DragonglassTool.READ_NOTE_WITH_HASH,
+    }:
+        _rename_first(args, _START_LINE_ALIASES, "start_line")
+        _rename_first(args, _END_LINE_ALIASES, "end_line")
+
+    if name == DragonglassTool.REPLACE_LINES:
+        _rename_first(args, _REPLACEMENT_ALIASES, "replacement")
+
+    if name == DragonglassTool.INSERT_AFTER_LINE:
+        _rename_first(args, _LINE_ALIASES, "line")
+        _rename_first(args, _TEXT_ALIASES, "text")
+
+    if name in {DragonglassTool.MANAGE_FRONTMATTER, DragonglassTool.MANAGE_TAGS}:
+        _rename_first(args, _OPERATION_ALIASES, "operation")
+
+
 class VaultAgent:
     def __init__(self, settings: Settings) -> None:
         self._settings = settings
@@ -659,6 +820,7 @@ class VaultAgent:
             return f"Search server error: {exc}"
 
     async def _call_tool(self, name: str, args: dict[str, JsonValue]) -> str:
+        _coerce_args(name, args)
         if name in _SEARCH_TOOLS:
             return await self._call_search_tool(name, args)
 

--- a/dragonglass/agent/runtime.py
+++ b/dragonglass/agent/runtime.py
@@ -8,6 +8,7 @@ import logging
 import typing
 import uuid
 
+import fastmcp.exceptions
 import litellm
 from mcp import ClientSession
 from mcp.types import TextContent
@@ -26,7 +27,6 @@ from dragonglass.agent.mcp import (
 )
 from dragonglass.agent.opencode import run_opencode_turn
 from dragonglass.agent.parsing import (
-    _extract_tool_errors,
     _is_error_result,
     _is_validation_error_result,
     _truncate_result,
@@ -642,23 +642,25 @@ class VaultAgent:
                     Message(role="tool", tool_call_id=tc.id, content=result)
                 )
 
+    async def _call_search_tool(self, name: str, args: dict[str, JsonValue]) -> str:
+        try:
+            result = await self._search.call_tool(name, args)
+            first = result.content[0] if result.content else None
+            text = first.text if isinstance(first, TextContent) else "[]"
+            return _truncate_result(text)
+        except fastmcp.exceptions.ValidationError as exc:
+            logger.warning("search tool %r validation error: %s", name, exc)
+            return (
+                f"Tool '{name}' called with wrong arguments. {exc}. "
+                "Check the tool schema and use the exact parameter names and types."
+            )
+        except Exception as exc:
+            logger.warning("search server error calling %r: %s", name, exc)
+            return f"Search server error: {exc}"
+
     async def _call_tool(self, name: str, args: dict[str, JsonValue]) -> str:
         if name in _SEARCH_TOOLS:
-            try:
-                result = await self._search.call_tool(name, args)
-                first = result.content[0] if result.content else None
-                text = first.text if isinstance(first, TextContent) else "[]"
-                return _truncate_result(text)
-            except Exception as exc:
-                msg = str(exc)
-                logger.warning("search server error calling %r: %s", name, msg)
-                error_hint = _extract_tool_errors(msg)
-                if error_hint:
-                    return (
-                        f"Tool '{name}' called with wrong arguments. {error_hint}. "
-                        "Check the tool schema and use the exact parameter names and types."
-                    )
-                return f"Search server error: {exc}"
+            return await self._call_search_tool(name, args)
 
         exhausted = True
         for session in self._stdio_sessions:
@@ -669,6 +671,8 @@ class VaultAgent:
                     call_result = await session.call_tool(name, args)
                     first = call_result.content[0] if call_result.content else None
                     text = first.text if isinstance(first, TextContent) else ""
+                    if call_result.isError:
+                        return f"Tool '{name}' error: {text}"
                     return _truncate_result(text)
             except Exception:
                 logger.warning(


### PR DESCRIPTION
This pull request improves the reliability of tool execution by implementing strict error classification for MCP tools and adding a coercion layer to handle common LLM argument name variations.

## Major Changes

### MCP Error Classification Refactor
Replaced fragile regex-based string matching in the tool error handler with proper typed exception handling and result flags.
- Catching `fastmcp.exceptions.ValidationError` specifically to provide actionable feedback for schema violations (orange badge status).
- Added explicit `isError` check on stdio MCP call results to correctly identify tool-level failures.
- Removed the legacy `_extract_tool_errors` logic and regex heuristics from the parsing module.
- **Files**: [dragonglass/agent/parsing.py](dragonglass/agent/parsing.py) in 4fa334f, [dragonglass/agent/runtime.py](dragonglass/agent/runtime.py) in 4fa334f

### LLM Argument Coercion Utility
Introduced a normalization layer (`_coerce_args`) that executes before tool dispatch to map varied LLM parameter names to the canonical schema names expected by the backend tools.
- Handles common variations for file paths (`filePath`, `note_path`, etc.), search queries, and line ranges.
- Automatically normalizes camelCase, snake_case, and semantic variants (e.g., `top_k` vs `top_n`).
- Implemented robust parsing for list parameters which can sometimes be passed as comma-separated strings by the LLM.
- **Files**: [dragonglass/agent/runtime.py](dragonglass/agent/runtime.py) in f203cc7


Fixes #56.
Fixes #52.