### PR TITLE
fix: focus input on open, fix collapsible section clicks

### DIFF
--- a/DragonglassApp/Dragonglass/CollapsedToolSummary.swift
+++ b/DragonglassApp/Dragonglass/CollapsedToolSummary.swift
@@ -34,6 +34,9 @@ struct CollapsedToolSummary: View {
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .textSelection(.disabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(Rectangle())
+                    .onTapGesture { isExpanded.toggle() }
             }
         )
     }

--- a/DragonglassApp/Dragonglass/InputBarView.swift
+++ b/DragonglassApp/Dragonglass/InputBarView.swift
@@ -7,6 +7,7 @@ struct InputBarView: View {
     @Binding var inputText: String
     let onSend: () -> Void
     let onSTT: (String) -> Void
+    @FocusState private var isFocused: Bool
 
     var body: some View {
         HStack {
@@ -14,6 +15,7 @@ struct InputBarView: View {
                 .textFieldStyle(.plain)
                 .onSubmit(onSend)
                 .disabled(client.isThinking)
+                .focused($isFocused)
 
             MicButton()
                 .environmentObject(sttManager)
@@ -38,6 +40,7 @@ struct InputBarView: View {
         }
         .padding()
         .background(Color(NSColor.controlBackgroundColor))
+        .onAppear { isFocused = true }
         .onChange(of: sttManager.pendingText) { _, text in
             if let text { inputText = text }
         }

--- a/DragonglassApp/Dragonglass/SettingsView.swift
+++ b/DragonglassApp/Dragonglass/SettingsView.swift
@@ -64,7 +64,7 @@ struct SettingsView: View {
                                 .environmentObject(sttManager)
                                 .environmentObject(hotkeyManager)
                         }
-                        DisclosureGroup("Advanced") {
+                        DisclosureGroup {
                             VStack(alignment: .leading, spacing: 12) {
                                 settingsSection("Environment Variables") {
                                     EnvironmentSettingsSection(
@@ -76,6 +76,10 @@ struct SettingsView: View {
                                 }
                             }
                             .padding(.top, 8)
+                        } label: {
+                            Text("Advanced")
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .contentShape(Rectangle())
                         }
                         .font(.caption)
                         .foregroundColor(.secondary)

--- a/DragonglassApp/Dragonglass/SpeechSettingsView.swift
+++ b/DragonglassApp/Dragonglass/SpeechSettingsView.swift
@@ -99,6 +99,9 @@ struct SpeechSettingsView: View {
                     .font(.caption2)
                 }
             }
+            .frame(maxWidth: .infinity)
+            .contentShape(Rectangle())
+            .onTapGesture { modelsExpanded.toggle() }
         }
         .font(.caption)
     }


### PR DESCRIPTION
This pull request introduces UX improvements focusing on input accessibility and navigation within the macOS application.

## Major Changes

### Interaction Improvements

#### Programmatic Focus for Chat Input
- The chat input field now automatically receives focus when the interface appears. This streamlines the user experience by allowing immediate typing without requiring an initial click or navigation away from the model picker.
- Changed file: [DragonglassApp/Dragonglass/InputBarView.swift](DragonglassApp/Dragonglass/InputBarView.swift)
- Revision: a91305dcd741b03125033d78e934e59b4309d4c5

#### Enhanced Tappable Areas for Disclosure Groups
- Improved the interaction model for collapsible sections across several views. The entire header area is now interactive, making it significantly easier to expand and collapse sections compared to targeting the small chevron icon.
- Changed files:
    - [DragonglassApp/Dragonglass/CollapsedToolSummary.swift](DragonglassApp/Dragonglass/CollapsedToolSummary.swift)
    - [DragonglassApp/Dragonglass/SettingsView.swift](DragonglassApp/Dragonglass/SettingsView.swift)
    - [DragonglassApp/Dragonglass/SpeechSettingsView.swift](DragonglassApp/Dragonglass/SpeechSettingsView.swift)
- Revision: c991fd168f9f5cd6269c3fc48bca3cd436ba20a9


Fixes #51, fixes #55